### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.0.1] - 2026-07-19
+
+Patch release. Activity MET auto-estimate now uses your latest
+weight from Body Stats or a smart-scale sync (Withings, Fitbit,
+Garmin, Health Connect) instead of the static onboarding value,
+and the hint no longer points at a non-existent Profile field.
+Small polish on how the Activity row renders in the Diary.
+
+### Fixed
+
+- **Activity MET auto-estimate uses fresh weight.** Reads from
+  Body Stats or wellness data, not just the onboarding Wizard's
+  static field. (#99, reported by @tellis82)
+- **MET hint shows weight in your preferred unit.** Imperial gets
+  `kg (lb)`, metric stays `kg`.
+- **Activity diary rows format distance with units.** "20" now
+  renders as "20 mi" / "20 km" per your setting.
+
+---
+
 ## [1.0.0] - 2026-07-19
 
 First stable release under the new semver scheme. Retires -rc.N.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.nutritrace.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 125
-        versionName "1.0.0"
+        versionCode 126
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nutritrace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -196,6 +196,29 @@ router.use('/api/wellness/google-health', googleHealthRoutes);
 router.use('/api/wellness/withings',      withingsRoutes);
 router.use('/api/wellness/garmin',        garminRoutes);
 
+// Cross-source latest wellness metric lookup. Returns the most recent
+// row for a given metric_type across all sources (Fitbit / Withings /
+// Garmin / Health Connect / etc.), which is what the Activity sheet's
+// MET auto-estimate needs to grab the freshest weight_kg regardless of
+// which scale wrote it (#99). Returns { date, value, source } or null.
+router.get('/api/wellness/latest', (req, res) => {
+  const userId = req.user?.id;
+  const metric = String(req.query.metric || '').trim();
+  if (!metric) return res.status(400).json({ error: 'metric query param required' });
+  const row = userId
+    ? db.prepare(
+        `SELECT date, value, source FROM wellness_data
+         WHERE user_id = ? AND metric_type = ? AND value > 0
+         ORDER BY date DESC LIMIT 1`
+      ).get(userId, metric)
+    : db.prepare(
+        `SELECT date, value, source FROM wellness_data
+         WHERE user_id IS NULL AND metric_type = ? AND value > 0
+         ORDER BY date DESC LIMIT 1`
+      ).get(metric);
+  res.json(row || null);
+});
+
 // Cross-source calories_out lookup — for Dynamic Calorie Goal
 // Returns yesterday's merged TDEE from fitbit/garmin/health_connect/lifttrace
 router.get('/api/wellness/calories-out', (req, res) => {

--- a/src/components/diary/AddActivitySheet.svelte
+++ b/src/components/diary/AddActivitySheet.svelte
@@ -49,37 +49,55 @@
       userKcalOverridden = !!entry;      // editing an existing row = user's own number
       showSuggestions = false;
       // Weight source for the MET → kcal preview. Priority chain (#99):
-      //   1. most recent body_stats.weight from the diary — updated any time
-      //      the user opens Body Stats and logs a weigh-in
-      //   2. weight_kg setting from onboarding Wizard — static, set once
-      // The Wizard value was the only source pre-fix; a reporter (#99)
-      // pointed out it never updates and the hint told users to "add
-      // weight in Profile" even though Profile has no such field.
+      //   1. freshest of {body_stats.weight, wellness_data.weight_kg} — the
+      //      wellness_data path covers users with a smart scale (Withings,
+      //      Fitbit Aria, Garmin Index, HC BodyComp) whose weight never
+      //      lands in the diary's body_stats blob.
+      //   2. weight_kg setting from onboarding Wizard — static, set once.
+      // Original fix only checked body_stats and missed reporter (#99)'s
+      // Withings-scale case.
       //
       // Seed from the setting synchronously so the preview can render
-      // immediately; then override async with the fresher body_stats
-      // weight when it arrives. Any fetch failure silently keeps the
-      // synchronous seed — never worse than before.
+      // immediately; then override async with whichever real weight-log
+      // source has the most recent date. Any fetch failure silently keeps
+      // the synchronous seed — never worse than before.
       try {
         const raw = DB.getSetting('weight_kg', null);
         userWeightKg = raw != null && !isNaN(Number(raw)) ? Number(raw) : null;
       } catch { userWeightKg = null; }
-      NtApi.getAllDiary()
-        .then(rows => {
-          if (!Array.isArray(rows) || rows.length === 0) return;
-          // Walk backward from most-recent date, first non-empty
-          // body_stats.weight wins. readBodyStat handles kg/lb tag
-          // conversion so we always land in kg for the MET formula.
+      Promise.all([
+        NtApi.getAllDiary().catch(() => []),
+        NtApi.getLatestWellness('weight_kg').catch(() => null),
+      ]).then(([rows, wellnessLatest]) => {
+        // Walk diary backward to find the most recent body_stats.weight
+        // and its date; readBodyStat converts kg/lb tag to kg.
+        let bodyLatest = null;
+        if (Array.isArray(rows) && rows.length > 0) {
           const sorted = [...rows].sort((a, b) => (b.date || '').localeCompare(a.date || ''));
           for (const r of sorted) {
             const bs = r.body_stats || r.bodyStats;
             if (bs && bs.weight != null && bs.weight !== '') {
               const wKg = readBodyStat(bs, 'weight', 'kg');
-              if (wKg != null && wKg > 0) { userWeightKg = wKg; break; }
+              if (wKg != null && wKg > 0) { bodyLatest = { date: r.date, wKg }; break; }
             }
           }
-        })
-        .catch(() => { /* keep the Wizard-setting fallback already assigned above */ });
+        }
+        // Wellness value is already in kg (metric_type='weight_kg' is
+        // canonical). Guard against 0/negative just in case.
+        const wellVal = wellnessLatest && wellnessLatest.value > 0
+          ? { date: wellnessLatest.date, wKg: Number(wellnessLatest.value) }
+          : null;
+        // Pick whichever source has the newer date. When both are on the
+        // same day, prefer body_stats (user's most-recent manual weigh-in
+        // wins over a passive scale sync).
+        let pick = null;
+        if (bodyLatest && wellVal) {
+          pick = (bodyLatest.date >= wellVal.date) ? bodyLatest : wellVal;
+        } else {
+          pick = bodyLatest || wellVal;
+        }
+        if (pick && pick.wKg > 0) userWeightKg = pick.wKg;
+      });
       // Past 90 days of names (existing behavior) + templates (new). Both
       // fire-and-forget so the sheet is usable even if the fetch fails.
       const today = new Date();

--- a/src/components/diary/AddActivitySheet.svelte
+++ b/src/components/diary/AddActivitySheet.svelte
@@ -8,6 +8,7 @@
   import { NtApi } from '../../lib/api.js';
   import { DB } from '../../lib/db.js';
   import { ACTIVITIES, search as searchCompendium, metKcal, findById } from '../../lib/activity-picker.js';
+  import { readBodyStat } from '../../lib/body-stats-unit.js';
   import ActivityCategoryPicker from './ActivityCategoryPicker.svelte';
 
   export let open = false;
@@ -47,13 +48,38 @@
       error       = '';
       userKcalOverridden = !!entry;      // editing an existing row = user's own number
       showSuggestions = false;
-      // Pull weight_kg from user profile for the live MET → kcal preview.
-      // Any value we get is fine; if the field is missing the preview
-      // silently hides and the user just types kcal like today.
+      // Weight source for the MET → kcal preview. Priority chain (#99):
+      //   1. most recent body_stats.weight from the diary — updated any time
+      //      the user opens Body Stats and logs a weigh-in
+      //   2. weight_kg setting from onboarding Wizard — static, set once
+      // The Wizard value was the only source pre-fix; a reporter (#99)
+      // pointed out it never updates and the hint told users to "add
+      // weight in Profile" even though Profile has no such field.
+      //
+      // Seed from the setting synchronously so the preview can render
+      // immediately; then override async with the fresher body_stats
+      // weight when it arrives. Any fetch failure silently keeps the
+      // synchronous seed — never worse than before.
       try {
         const raw = DB.getSetting('weight_kg', null);
         userWeightKg = raw != null && !isNaN(Number(raw)) ? Number(raw) : null;
       } catch { userWeightKg = null; }
+      NtApi.getAllDiary()
+        .then(rows => {
+          if (!Array.isArray(rows) || rows.length === 0) return;
+          // Walk backward from most-recent date, first non-empty
+          // body_stats.weight wins. readBodyStat handles kg/lb tag
+          // conversion so we always land in kg for the MET formula.
+          const sorted = [...rows].sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+          for (const r of sorted) {
+            const bs = r.body_stats || r.bodyStats;
+            if (bs && bs.weight != null && bs.weight !== '') {
+              const wKg = readBodyStat(bs, 'weight', 'kg');
+              if (wKg != null && wKg > 0) { userWeightKg = wKg; break; }
+            }
+          }
+        })
+        .catch(() => { /* keep the Wizard-setting fallback already assigned above */ });
       // Past 90 days of names (existing behavior) + templates (new). Both
       // fire-and-forget so the sheet is usable even if the fetch fails.
       const today = new Date();

--- a/src/components/diary/AddActivitySheet.svelte
+++ b/src/components/diary/AddActivitySheet.svelte
@@ -3,7 +3,7 @@
   import { _ } from 'svelte-i18n';
   import Sheet from '../ui/Sheet.svelte';
   import { addActivity, updateActivity } from '../../stores/activity.js';
-  import { energyUnit, distUnit } from '../../stores/settings.js';
+  import { energyUnit, distUnit, weightUnit } from '../../stores/settings.js';
   import { Nutrition } from '../../lib/nutrition.js';
   import { NtApi } from '../../lib/api.js';
   import { DB } from '../../lib/db.js';
@@ -303,8 +303,12 @@
       <input class="input" type="number" bind:value={kcal} on:input={onKcalInput}
         inputmode="numeric" min="0" placeholder={$energyUnit === 'kJ' ? '500' : '120'} />
       {#if previewKcal != null && met != null}
+        {@const _wKgRounded = userWeightKg.toFixed(1)}
+        {@const _weightDisp = $weightUnit === 'lb'
+          ? `${_wKgRounded} kg (${(userWeightKg * 2.20462).toFixed(1)} lb)`
+          : `${_wKgRounded} kg`}
         <span class="kcal-hint">
-          {$_('diary.activity.kcal_preview', { values: { met: met.toFixed(1), weight: userWeightKg, duration: durationMin, kcal: previewKcal } })}
+          {$_('diary.activity.kcal_preview', { values: { met: met.toFixed(1), weight_display: _weightDisp, duration: durationMin, kcal: previewKcal } })}
         </span>
       {:else if met != null && userWeightKg == null}
         <span class="kcal-hint kcal-hint-warn">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -432,7 +432,7 @@
       "save_as_template":     "Save as template",
       "save_as_template_hint": "(pinned in the picker next time)",
       "kcal_preview":         "MET {met} × {weight} kg × {duration} min → {kcal} kcal",
-      "no_weight_hint":       "Add weight in Profile for MET-based auto-estimate",
+      "no_weight_hint":       "Log a weight in Body Stats to enable MET-based auto-estimate",
       "suggest": {
         "templates":          "Templates",
         "past_entries":       "Past entries",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -431,7 +431,7 @@
       "policy_chip":          "Policy: wearable wins. Toggle in Settings → Diary.",
       "save_as_template":     "Save as template",
       "save_as_template_hint": "(pinned in the picker next time)",
-      "kcal_preview":         "MET {met} × {weight} kg × {duration} min → {kcal} kcal",
+      "kcal_preview":         "MET {met} × {weight_display} × {duration} min → {kcal} kcal",
       "no_weight_hint":       "Log a weight in Body Stats to enable MET-based auto-estimate",
       "suggest": {
         "templates":          "Templates",

--- a/src/lib/api-native.js
+++ b/src/lib/api-native.js
@@ -245,6 +245,7 @@ export const NtApiNative = {
       return await computeAdaptiveTdeeLocal();
     }
     if (path.startsWith('/api/wellness/calories-out')) return _caloriesOutLocal(path);
+    if (path.startsWith('/api/wellness/latest'))       return _latestWellnessLocal(path);
     if (path.startsWith('/api/wellness/fitbit/data'))   return _wellnessDataLocal(path, ['fitbit', 'health_connect']);
     if (path.startsWith('/api/wellness/garmin/data'))   return _wellnessDataLocal(path, ['garmin']);
     if (path.startsWith('/api/wellness/withings/data')) return _wellnessDataLocal(path, ['withings']);
@@ -344,6 +345,28 @@ async function _caloriesOutLocal(path) {
     if (row) return { calories_out: row.value, source: src, date: yesterday };
   }
   return { calories_out: null, source: null, date: yesterday };
+}
+
+// Local dispatcher for /api/wellness/latest?metric=<name>. Mirrors the
+// server endpoint: returns the most recent wellness_data row across all
+// sources for a metric_type. Used by AddActivitySheet's MET auto-estimate
+// weight lookup (#99). Native local mode typically only has Health Connect
+// rows (Withings/Fitbit/Garmin sync happens server-side), but the query
+// is source-agnostic so any local rows count.
+async function _latestWellnessLocal(path) {
+  const { getDb, LOCAL_USER_ID } = await import('./db-native.js');
+  const q = new URLSearchParams(path.includes('?') ? path.split('?')[1] : '');
+  const metric = q.get('metric');
+  if (!metric) return null;
+  const db = await getDb();
+  const r = await db.query(
+    `SELECT date, value, source FROM wellness_data
+      WHERE user_id = ? AND metric_type = ? AND value > 0
+      ORDER BY date DESC LIMIT 1`,
+    [LOCAL_USER_ID, metric]
+  );
+  const rows = r?.values || [];
+  return rows[0] || null;
 }
 
 // Local dispatcher for per-source /api/wellness/<source>/data?date= or

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -600,6 +600,11 @@ const _NtApiHttp = {
   saveDiaryDate(date, data) { return this.put(`/api/diary/${date}`, data); },
   getAllDiary()              { return this.get('/api/diary'); },
 
+  // Latest wellness_data row across all sources for a metric — used by
+  // AddActivitySheet for MET auto-estimate weight lookup (#99). Returns
+  // { date, value, source } or null.
+  getLatestWellness(metric) { return this.get(`/api/wellness/latest?metric=${encodeURIComponent(metric)}`); },
+
   // Activity (manual exercise/calorie-burn entries)
   getActivity(date)          { return this.get(`/api/activity/${date}`); },
   getActivitySum(date, policy = 'wearable_wins') { return this.get(`/api/activity/sum/${date}?policy=${encodeURIComponent(policy)}`); },

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = 'v1.0.0';
+export const APP_VERSION = 'v1.0.1';

--- a/src/routes/Diary.svelte
+++ b/src/routes/Diary.svelte
@@ -30,7 +30,7 @@
   import { mealNames, goals, energyUnit, weightUnit, lengthUnit, navStyle,
            diaryShowBrands, diaryShowThumbnails,
            diaryShowTimestamps, diaryShowMacroSummary, diaryPromptQuantity,
-           diaryShowPortionSize, diaryShowNotes, diaryShowNutritionBar, diaryTotalsMode, macroLegendMode,
+           diaryShowPortionSize, diaryShowNotes, diaryShowNutritionBar, diaryTotalsMode, macroLegendMode, distUnit,
            diaryShowAllNutrients, diaryShowNutritionUnits, visibleNutriments, hiddenBodyStats,
            showQuickCalories, quickCaloriesDisplay,
            dateFormat, timeFormat, disableAnimations, goalCelebrations, pageBanners, bannerStyle,
@@ -1469,7 +1469,7 @@
                   <div class="item-info">
                     <span class="item-name truncate">{a.name}</span>
                     <span class="item-meta text-3 text-sm">
-                      {#if a.duration_min}{a.duration_min} min{/if}{#if a.duration_min && a.distance} · {/if}{#if a.distance}{a.distance}{/if}{#if (a.duration_min || a.distance)} · {/if}<span style="color:#4FFFB0">−{_aEnergy.value.toLocaleString()} {_aEnergy.unit}</span>{#if a.source === 'ai_estimated'} · <span class="text-3" title="Estimated by Trace">{$_('diary.activity.estimated_short')}</span>{/if}
+                      {#if a.duration_min}{a.duration_min} min{/if}{#if a.duration_min && a.distance} · {/if}{#if a.distance}{@const _dStr = String(a.distance).trim()}{_dStr}{#if /^\d+(\.\d+)?$/.test(_dStr)} {$distUnit || 'mi'}{/if}{/if}{#if (a.duration_min || a.distance)} · {/if}<span style="color:#4FFFB0">−{_aEnergy.value.toLocaleString()} {_aEnergy.unit}</span>{#if a.source === 'ai_estimated'} · <span class="text-3" title="Estimated by Trace">{$_('diary.activity.estimated_short')}</span>{/if}
                     </span>
                   </div>
                 </button>

--- a/src/routes/Diary.svelte
+++ b/src/routes/Diary.svelte
@@ -1469,7 +1469,7 @@
                   <div class="item-info">
                     <span class="item-name truncate">{a.name}</span>
                     <span class="item-meta text-3 text-sm">
-                      {#if a.duration_min}{a.duration_min} min{/if}{#if a.duration_min && a.distance} · {/if}{#if a.distance}{@const _dStr = String(a.distance).trim()}{_dStr}{#if /^\d+(\.\d+)?$/.test(_dStr)} {$distUnit || 'mi'}{/if}{/if}{#if (a.duration_min || a.distance)} · {/if}<span style="color:#4FFFB0">−{_aEnergy.value.toLocaleString()} {_aEnergy.unit}</span>{#if a.source === 'ai_estimated'} · <span class="text-3" title="Estimated by Trace">{$_('diary.activity.estimated_short')}</span>{/if}
+                      {#if a.duration_min}{a.duration_min} min{/if}{#if a.duration_min && a.distance} | {/if}{#if a.distance}{@const _dStr = String(a.distance).trim()}{_dStr}{#if /^\d+(\.\d+)?$/.test(_dStr)} {$distUnit || 'mi'}{/if}{/if}{#if (a.duration_min || a.distance)} | {/if}<span style="color:#4FFFB0">−{_aEnergy.value.toLocaleString()} {_aEnergy.unit}</span>{#if a.source === 'ai_estimated'} | <span class="text-3" title="Estimated by Trace">{$_('diary.activity.estimated_short')}</span>{/if}
                     </span>
                   </div>
                 </button>


### PR DESCRIPTION
Patch release. Fixes the Activity MET auto-estimate weight lookup + polish on Activity diary rows.

- #99 fix — reads weight from body_stats or wellness_data (Withings/Fitbit/Garmin/HC), not just Wizard setting
- MET hint shows lb in parens for imperial users
- Activity diary distance rows format with unit; · separator swapped for |

Full CHANGELOG in the merge diff.