### PR TITLE
release: v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.0.2] - 2026-07-22
+
+Patch release. Fixes long-press to open the food/meal/recipe action
+sheet on iOS Safari, plus a high-severity brace-expansion CVE bump.
+
+### Fixed
+
+- **Long-press works on Foods/Meals/Recipes lists in iOS Safari.**
+  The Diary tab already used a manual touch timer to detect long-press;
+  the Foods tab only listened for `contextmenu`, which iOS Safari
+  doesn't dispatch for long-press on non-text elements. Ported the
+  same touch-timer pattern to Foods/Meals/Recipes so long-press
+  opens the edit/clone/delete action sheet across every browser.
+  (#102, reported by @javydekoning)
+
+### Security
+
+- **brace-expansion bumped to 5.0.7 (CVE-2026-13149, high).**
+  Regex denial-of-service in the expansion parser. Transitive dep;
+  no direct code change required.
+
+---
+
 ## [1.0.1] - 2026-07-19
 
 Patch release. Activity MET auto-estimate now uses your latest

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.nutritrace.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 126
-        versionName "1.0.1"
+        versionCode 127
+        versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nutritrace",
-  "version": "1.0.0-rc.52",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nutritrace",
-      "version": "1.0.0-rc.52",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "dependencies": {
         "@aparajita/capacitor-biometric-auth": "^10.0.0",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4411,9 +4411,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -4482,9 +4482,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nutritrace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = 'v1.0.1';
+export const APP_VERSION = 'v1.0.2';

--- a/src/routes/Foods.svelte
+++ b/src/routes/Foods.svelte
@@ -867,6 +867,21 @@
     showItemActions = true;
   }
 
+  // Manual long-press timer for iOS Safari, which doesn't dispatch
+  // `contextmenu` events on long-press for non-text elements (especially
+  // when the element sets `-webkit-touch-callout: none`, which .food-item-btn
+  // does). touchstart/touchmove/touchend always fire on iOS, so we detect
+  // the hold ourselves and trigger the same action sheet. Mirrors the
+  // Diary's implementation. iOS also suppresses synthetic click after a
+  // >300ms hold, so no double-fire risk at 500ms. #102.
+  let _lpTimer = null;
+  function _startLongPress(action) {
+    _lpTimer = setTimeout(() => { _lpTimer = null; action(); }, 500);
+  }
+  function _cancelLongPress() {
+    if (_lpTimer) { clearTimeout(_lpTimer); _lpTimer = null; }
+  }
+
   function handleItemAction({ detail }) {
     if (!selectedItem) return;
     if (detail.value === 'edit') {
@@ -1278,7 +1293,10 @@
             <li class="food-item card" in:fade={{ duration: 140 }}>
               <button class="food-item-btn"
                 on:click={() => _pickBySource(source, item)}
-                on:contextmenu|preventDefault={() => !isMealie && !isExternal && longPress(item)}>
+                on:contextmenu|preventDefault={() => !isMealie && !isExternal && longPress(item)}
+                on:touchstart|passive={() => _startLongPress(() => !isMealie && !isExternal && longPress(item))}
+                on:touchmove|passive={_cancelLongPress}
+                on:touchend={_cancelLongPress}>
                 {#if isMealie && item.id}
                   <img class="food-thumb" src={Mealie.imageUrl(item.id)} alt=""
                     loading="lazy" on:error={e => e.target.style.display='none'} />
@@ -1403,7 +1421,10 @@
               {/if}
               <button class="food-item-btn"
                 on:click={() => manageMode ? toggleManageSelect(food) : pickFood(food)}
-                on:contextmenu|preventDefault={() => !manageMode && longPress(food)}>
+                on:contextmenu|preventDefault={() => !manageMode && longPress(food)}
+                on:touchstart|passive={() => _startLongPress(() => !manageMode && longPress(food))}
+                on:touchmove|passive={_cancelLongPress}
+                on:touchend={_cancelLongPress}>
                 {#if $foodsShowThumbnails && food.imgUrl}
                   <img class="food-thumb" src={food.imgUrl} alt="" loading="lazy" referrerpolicy="no-referrer" on:error={e => e.target.style.display='none'} />
                 {:else}
@@ -1478,7 +1499,10 @@
                 {/if}
                 <button class="food-item-btn"
                   on:click={() => pickFood(food)}
-                  on:contextmenu|preventDefault={() => longPress(food)}>
+                  on:contextmenu|preventDefault={() => longPress(food)}
+                  on:touchstart|passive={() => _startLongPress(() => longPress(food))}
+                  on:touchmove|passive={_cancelLongPress}
+                  on:touchend={_cancelLongPress}>
                   {#if food.imgUrl}
                     <img class="food-thumb" src={food.imgUrl} alt="" loading="lazy" referrerpolicy="no-referrer" on:error={e => e.target.style.display='none'} />
                   {:else}


### PR DESCRIPTION
Patch release. iOS Safari long-press fix on Foods/Meals/Recipes (#102) + brace-expansion CVE-2026-13149 bump. Full CHANGELOG in the merge diff.