### PR TITLE
release: v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.0.5] - 2026-07-29
+
+### Fixed
+
+- **Backups, SMTP config, and other admin panels now work in single-user mode.** With User Management turned off, `POST /api/full-backup`, `PUT /api/app-config`, `POST /api/app-config/test-email`, `POST /api/off-local/refresh`, `GET /api/updates/server-status`, and related admin routes all returned 403 "Admin only" even though NutriTrace's own frontend correctly identifies the sole owner as effectively-admin. `requireAdmin` middleware now passes through when User Management is off, mirroring `requireAuth`. Fourteen previously-broken admin routes come back to life. LiftTrace already had this fix; parity restored. Reported in [#118](https://github.com/traceapps/nutritrace/issues/118).
+
+---
+
 ## [1.0.4] - 2026-07-28
 
 ### Changed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.nutritrace.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 129
-        versionName "1.0.4"
+        versionCode 130
+        versionName "1.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nutritrace",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -71,8 +71,13 @@ export function requireAuth(req, res, next) {
   next();
 }
 
-/** Require admin role */
+/** Require admin role. When user management is off the whole admin/non-admin
+ *  distinction is meaningless (the single user IS the owner), so pass through
+ *  in that mode — mirrors requireAuth above. Without this, admin-gated routes
+ *  like POST /api/full-backup are unreachable from single-user installs even
+ *  though the frontend correctly identifies them as effectively-admin. */
 export function requireAdmin(req, res, next) {
+  if (!userMgmtActive()) return next();  // single-user mode = effectively admin
   if (!req.user || req.user.role !== 'admin') return res.status(403).json({ error: 'Admin only' });
   next();
 }

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = 'v1.0.4';
+export const APP_VERSION = 'v1.0.5';


### PR DESCRIPTION
## Summary

Patch release. One user-facing change:

- **Admin-gated routes now work in single-user mode.** `requireAdmin` middleware passes through when User Management is off (mirroring `requireAuth`). Restores Full Backup, SMTP config + test-email, sharing config, OFF-local refresh, admin update-available banner — 14 endpoints total that were 403 "Admin only" for single-user installs. Same fix as CT v1.0.3. Related to #118.

## Test plan

- [x] `requireAdmin` middleware syntax-verified + no `req.user` deref downstream in the affected routes
- [x] `npm audit` clean on branch (root + server: 0 vulns)
- [x] `npm run build` clean
- [ ] Smoke test on live single-user server after tag (Create Backup / Send Test Email)