### PR TITLE
Fix/diary payload request tracing. Fixes #125

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,10 +77,14 @@ JWT_SECRET=change-me-to-a-long-random-secret
 # a URL ending in .duckdb and use a .duckdb extension on OFF_LOCAL_DB.
 # OFF_LOCAL_URL=https://huggingface.co/datasets/openfoodfacts/product-database/resolve/main/food.parquet?download=true
 
-# Optional — Log level (error | warn | info | debug)
+# Optional — Log level (error | warn | info | debug | trace)
 # Default: info — logs requests, warnings, and errors
 # Set to 'debug' for verbose wellness sync output (Fitbit, Withings, Garmin, Health Connect)
+# Set to 'trace' to also log redacted JSON bodies for POST/PUT/PATCH requests.
+# Trace bodies are truncated to 32 KiB by default; inline image data is never
+# printed. Override the cap with TRACE_BODY_MAX_BYTES if needed.
 # LOG_LEVEL=info
+# TRACE_BODY_MAX_BYTES=32768
 
 # Optional — SMTP email (for password reset & user invites)
 # If set, these override whatever is configured in the Settings UI AND lock those fields for all users

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Pre-release testers can grab the rolling `dev-latest` APK; occasional milestone 
 | `UPLOADS_PATH` | Yes | `/data/uploads` | Upload directory inside the container. |
 | `PORT` | No | `3001` | Container-side port the server listens on. |
 | `BASE_URL` | No |  | Subpath prefix when mounted behind a reverse proxy (e.g. `/nt`). |
-| `LOG_LEVEL` | No | `info` | `error` \| `warn` \| `info` \| `debug`. |
+| `LOG_LEVEL` | No | `info` | `error` \| `warn` \| `info` \| `debug` \| `trace`. |
+| `TRACE_BODY_MAX_BYTES` | No | `32768` | Maximum serialized request-body bytes logged at `trace` level. |
 | `INSECURE_COOKIES` | If on plain HTTP | unset | `1` drops the `Secure` cookie flag; needed only on plain-HTTP LAN. See [docs/getting-started/lan-http/](https://traceapps.github.io/docs/getting-started/lan-http/). |
 | `MAX_SESSION_HOURS` | No | `720` | Auth cookie lifetime. |
 | `RECOVERY_TOKEN` | No |  | Passphrase to disable user management from the login page (lockout recovery). |
@@ -118,6 +119,12 @@ Pre-release testers can grab the rolling `dev-latest` APK; occasional milestone 
 | `SMTP_HOST` | No |  | SMTP server for password reset & invites; also `SMTP_PORT` (587), `SMTP_SECURE` (false), `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`. |
 
 Full list (Docker secrets `*_FILE` variants, air-gap `OFF_LOCAL_ONLY`, per-provider AI knobs, all `OIDC_*` options) at [docs/self-hosting/env-vars/](https://traceapps.github.io/docs/self-hosting/env-vars/). SMTP and AI can also be set in the Settings UI; env vars take priority and lock those fields.
+
+### Request logging
+
+Request logs include the method, path, response status, duration, and the observed body size for `POST`, `PUT`, and `PATCH` requests. Oversized JSON requests return HTTP 413 with `size_bytes` and `limit_bytes` fields to make the configured limit visible.
+
+Set `LOG_LEVEL=trace` to also log parsed JSON request bodies. Credential-like fields are redacted, inline `data:` URLs are replaced with their byte size, query strings are omitted, and bodies are truncated to `TRACE_BODY_MAX_BYTES`. Request bodies can still contain private application data such as diary notes, so use trace logging only while diagnosing a problem.
 
 ## Data persistence
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ Request logs include the method, path, response status, duration, and the observ
 
 Set `LOG_LEVEL=trace` to also log parsed JSON request bodies. Credential-like fields are redacted, inline `data:` URLs are replaced with their byte size, query strings are omitted, and bodies are truncated to `TRACE_BODY_MAX_BYTES`. Request bodies can still contain private application data such as diary notes, so use trace logging only while diagnosing a problem.
 
+### Image storage maintenance
+
+On normal container startup, NutriTrace moves legacy inline food, meal, recipe, and diary images from SQLite into `UPLOADS_PATH`. It runs `VACUUM` before accepting requests only when that maintenance run actually localized database rows; an already-clean database is not exclusively locked and rewritten on every restart. The run has info-level start/finish summaries; set `LOG_LEVEL=debug` to also log each affected row, item ID, image size, and resulting upload path.
+
+Food and meal saves, sync pushes, imports, copies, and full-backup restores all localize inline images before writing SQLite. If an inline image cannot be decoded, validated, or written, the operation fails instead of storing the data URL in the database.
+
+Soft-deleted foods and meals retain their image references, and maintenance localizes those images as well. Maintenance does not delete upload files; image garbage collection should only remove files after accounting for active records, tombstones, and diary/recipe snapshot references.
+
+The bundled Compose file also provides an optional daily maintenance sidecar. It waits 24 hours with up to one hour of random jitter between runs, uses a shared database lease so it cannot overlap the startup process, and only vacuums after localizing rows:
+
+```bash
+docker compose --profile image-maintenance up -d
+```
+
+The sidecar mounts the same database and uploads directories as the main service. Keep both mounts identical if adapting the example.
+
 ## Data persistence
 
 Two host directories bind-mount:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,3 +112,22 @@ services:
       # - TOKEN_ENC_KEY_FILE=/run/secrets/nutritrace_token_enc_key
       # - RECOVERY_TOKEN_FILE=/run/secrets/nutritrace_recovery_token
     restart: unless-stopped
+
+  # Optional daily image localization + conditional SQLite compaction. The primary
+  # container always performs one foreground maintenance run before startup;
+  # enable this sidecar only when recurring maintenance is desired:
+  #   docker compose --profile image-maintenance up -d
+  nutritrace-image-maintenance:
+    image: ghcr.io/traceapps/nutritrace:latest
+    profiles: ["image-maintenance"]
+    command: ["node", "image-maintenance.js", "--loop"]
+    volumes:
+      - ${DATA_DB_PATH}:/data/db
+      - ${DATA_UPLOADS_PATH}:/data/uploads
+    env_file:
+      - .env
+    environment:
+      - DB_PATH=/data/db/nutritrace.db
+      - UPLOADS_PATH=/data/uploads
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    restart: unless-stopped

--- a/scripts/diary-payload.test.js
+++ b/scripts/diary-payload.test.js
@@ -23,3 +23,23 @@ test('stripInlineDiaryImages preserves the original array when unchanged', () =>
   assert.equal(stripInlineDiaryImages(items), items);
   assert.equal(stripInlineDiaryImages(null), null);
 });
+
+test('stripInlineDiaryImages removes nested recipe and snake-case images', () => {
+  const items = [{
+    id: 1,
+    imgUrl: '/uploads/recipe.jpg',
+    _splitItems: [
+      { id: 2, imgUrl: 'data:image/png;base64,abc' },
+      { id: 3, details: { img_url: 'data:image/jpeg;base64,def' } },
+    ],
+  }];
+
+  assert.deepEqual(stripInlineDiaryImages(items), [{
+    id: 1,
+    imgUrl: '/uploads/recipe.jpg',
+    _splitItems: [
+      { id: 2, imgUrl: '' },
+      { id: 3, details: { img_url: '' } },
+    ],
+  }]);
+});

--- a/scripts/diary-payload.test.js
+++ b/scripts/diary-payload.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { stripInlineDiaryImages } from '../src/lib/diary-payload.js';
+
+test('stripInlineDiaryImages removes only inline snapshot images', () => {
+  const items = [
+    { id: 1, imgUrl: 'data:image/jpeg;base64,abc', name: 'Photo food' },
+    { id: 2, imgUrl: '/uploads/food.jpg' },
+    { id: 3, imgUrl: 'https://images.example/food.jpg' },
+  ];
+
+  assert.deepEqual(stripInlineDiaryImages(items), [
+    { id: 1, imgUrl: '', name: 'Photo food' },
+    items[1],
+    items[2],
+  ]);
+  assert.equal(items[0].imgUrl, 'data:image/jpeg;base64,abc');
+});
+
+test('stripInlineDiaryImages preserves the original array when unchanged', () => {
+  const items = [{ id: 1, imgUrl: '/uploads/food.jpg' }];
+  assert.equal(stripInlineDiaryImages(items), items);
+  assert.equal(stripInlineDiaryImages(null), null);
+});

--- a/scripts/image-cache-map.test.js
+++ b/scripts/image-cache-map.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { originalUrlForCachedImage } from '../src/lib/image-cache-map.js';
+
+const cached = 'https://localhost/_capacitor_file_/data/image_cache/k9s3a.jpg';
+
+test('restores a relative server upload from a hashed Android cache path', () => {
+  const map = {
+    '/uploads/image-abc123.jpg': cached,
+    'https://food.example/uploads/image-abc123.jpg': cached,
+  };
+  assert.equal(originalUrlForCachedImage(cached, map), '/uploads/image-abc123.jpg');
+});
+
+test('normalizes an absolute server upload to a relative upload path', () => {
+  const map = {
+    'https://food.example/nutritrace/uploads/image-abc123.jpg': cached,
+  };
+  assert.equal(originalUrlForCachedImage(cached, map), '/uploads/image-abc123.jpg');
+});
+
+test('restores the full external URL instead of its pathname-only cache key', () => {
+  const map = {
+    '/images/products/front.en.400.jpg': cached,
+    'https://images.openfoodfacts.org/images/products/front.en.400.jpg': cached,
+  };
+  assert.equal(
+    originalUrlForCachedImage(cached, map),
+    'https://images.openfoodfacts.org/images/products/front.en.400.jpg'
+  );
+});
+
+test('unwraps a cached server proxy URL', () => {
+  const source = 'https://images.example/photo.jpg';
+  const map = {
+    [`https://food.example/api/proxy?url=${encodeURIComponent(source)}`]: cached,
+  };
+  assert.equal(originalUrlForCachedImage(cached, map), source);
+});
+
+test('returns null for a local file absent from the cache map', () => {
+  assert.equal(originalUrlForCachedImage(cached, {}), null);
+});

--- a/scripts/image-maintenance.test.js
+++ b/scripts/image-maintenance.test.js
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+test('image maintenance localizes canonical and nested snapshot images idempotently', async t => {
+  const serverRequire = createRequire(new URL('../server/package.json', import.meta.url));
+  try {
+    serverRequire.resolve('better-sqlite3');
+  } catch {
+    t.skip('server dependencies are not installed');
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nutritrace-image-maintenance-'));
+  const dbPath = path.join(tempDir, 'nutritrace.db');
+  const uploadsPath = path.join(tempDir, 'uploads');
+  process.env.DB_PATH = dbPath;
+  process.env.UPLOADS_PATH = uploadsPath;
+  process.env.LOG_LEVEL = 'error';
+
+  // A minimal magic-byte-valid PNG is sufficient for localization tests.
+  const png = Buffer.alloc(128);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png);
+  const dataUrl = `data:image/png;base64,${png.toString('base64')}`;
+
+  const { runImageMaintenance } = await import('../server/lib/image-maintenance.js');
+  const { localizeImageForStorage } = await import('../server/lib/image-localizer.js');
+  const { default: db } = await import('../server/db.js');
+
+  try {
+    await assert.rejects(
+      localizeImageForStorage('data:image/png;base64,AAAA', 'test image'),
+      err => err?.status === 422 && /inline image localization failed/.test(err.message)
+    );
+    await assert.rejects(
+      localizeImageForStorage('DATA:image/png;base64,AAAA', 'test image'),
+      err => err?.status === 422
+    );
+
+    // Simulate a final image file truncated by an older direct-write version.
+    // Localization must verify and atomically repair it rather than trusting
+    // the filename alone.
+    const hash = crypto.createHash('sha256').update(png).digest('hex').slice(0, 24);
+    const expectedFilename = `image-${hash}.png`;
+    fs.mkdirSync(uploadsPath, { recursive: true });
+    fs.writeFileSync(path.join(uploadsPath, expectedFilename), png.subarray(0, 16));
+
+    const food = db.prepare(
+      `INSERT INTO foods (name, img_url, updated_at, deleted_at)
+       VALUES (?, ?, datetime('now'), datetime('now'))`
+    ).run('Maintenance test food', dataUrl);
+    db.prepare(
+      `INSERT INTO diary (date, items, updated_at)
+       VALUES ('2099-01-01', ?, datetime('now'))`
+    ).run(JSON.stringify([{
+      id: food.lastInsertRowid,
+      imgUrl: dataUrl,
+      _splitItems: [{ id: 2, img_url: dataUrl }],
+    }]));
+
+    const first = await runImageMaintenance({ vacuum: true });
+    assert.equal(first.localized, 1);
+    assert.equal(first.snapshotRows, 1);
+    assert.equal(first.snapshotImages, 2);
+    assert.equal(first.failures, 0);
+    assert.equal(first.vacuumed, true);
+
+    const foodRow = db.prepare('SELECT img_url, deleted_at FROM foods WHERE id = ?').get(food.lastInsertRowid);
+    const diaryRow = db.prepare(`SELECT items FROM diary WHERE date = '2099-01-01'`).get();
+    const items = JSON.parse(diaryRow.items);
+    assert.match(foodRow.img_url, /^\/uploads\/image-[0-9a-f]{24}\.png$/);
+    assert.ok(foodRow.deleted_at, 'soft-deleted food remains a tombstone');
+    assert.equal(items[0].imgUrl, foodRow.img_url);
+    assert.equal(items[0]._splitItems[0].img_url, foodRow.img_url);
+    assert.equal(path.basename(foodRow.img_url), expectedFilename);
+    assert.deepEqual(fs.readFileSync(path.join(uploadsPath, expectedFilename)), png);
+    assert.deepEqual(fs.readdirSync(uploadsPath), [expectedFilename]);
+
+    const second = await runImageMaintenance({ vacuum: true });
+    assert.equal(second.localized, 0);
+    assert.equal(second.snapshotRows, 0);
+    assert.equal(second.failures, 0);
+    assert.equal(second.vacuumed, false);
+    assert.deepEqual(fs.readdirSync(uploadsPath), [expectedFilename]);
+  } finally {
+    db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/request-logging.test.js
+++ b/scripts/request-logging.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatBytes, formatTraceBody, requestLogPath } from '../server/middleware/request-logging.js';
+
+test('formatBytes presents request and limit sizes readably', () => {
+  assert.equal(formatBytes(0), '0 B');
+  assert.equal(formatBytes(1536), '1.5 KiB');
+  assert.equal(formatBytes(5 * 1024 * 1024), '5.00 MiB');
+  assert.equal(formatBytes(undefined), 'unknown');
+});
+
+test('formatTraceBody redacts credentials and summarizes inline images', () => {
+  const body = {
+    username: 'alice',
+    password: 'do-not-log',
+    nested: { api_key: 'also-secret' },
+    items: [{ imgUrl: 'data:image/jpeg;base64,abcdef' }],
+  };
+  const output = formatTraceBody(body);
+
+  assert.match(output, /"username":"alice"/);
+  assert.doesNotMatch(output, /do-not-log|also-secret|base64,abcdef/);
+  assert.match(output, /"password":"\[REDACTED\]"/);
+  assert.match(output, /"imgUrl":"\[data URL: 29 bytes\]"/);
+});
+
+test('formatTraceBody redacts secret values in key/value setting payloads', () => {
+  const output = formatTraceBody({ key: 'aiApiKey', value: 'do-not-log' });
+  assert.doesNotMatch(output, /do-not-log/);
+  assert.match(output, /"value":"\[REDACTED\]"/);
+});
+
+test('formatTraceBody truncates large serialized bodies', () => {
+  const output = formatTraceBody({ notes: 'x'.repeat(200) }, 100);
+  assert.ok(Buffer.byteLength(output) <= 100);
+  assert.match(output, /truncated; serialized body 212 B/);
+});
+
+test('requestLogPath excludes sensitive query strings', () => {
+  assert.equal(requestLogPath({
+    baseUrl: '/nutritrace',
+    path: '/api/auth/callback',
+    originalUrl: '/nutritrace/api/auth/callback?code=secret',
+  }), '/nutritrace/api/auth/callback');
+});

--- a/server/db.js
+++ b/server/db.js
@@ -7,6 +7,10 @@ fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
 const db = new Database(dbPath);
 db.pragma('journal_mode = WAL');
+// A maintenance sidecar may briefly hold an exclusive lock while VACUUM
+// compacts the database. Wait for it instead of surfacing transient
+// SQLITE_BUSY errors to API requests.
+db.pragma('busy_timeout = 30000');
 db.pragma('foreign_keys = ON');
 
 // ── Core tables ────────────────────────────────────────────────────────────

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -25,4 +25,11 @@ for file_var in $(env | sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*_FILE\)=.*/\1/p'); do
   unset "$file_var"
 done
 
+# Repair legacy inline images and compact SQLite before accepting requests.
+# Other commands (notably the optional --loop sidecar) skip this foreground
+# run; the primary server container is the single startup owner.
+if [ "${1-}" = "node" ] && [ "${2-}" = "index.js" ]; then
+  node image-maintenance.js --once
+fi
+
 exec "$@"

--- a/server/image-maintenance.js
+++ b/server/image-maintenance.js
@@ -1,0 +1,40 @@
+import { logger } from './logger.js';
+import { runImageMaintenance } from './lib/image-maintenance.js';
+
+const LOOP_BASE_MS = 24 * 60 * 60 * 1000;
+const LOOP_JITTER_MS = 60 * 60 * 1000;
+
+function nextDelay() {
+  return LOOP_BASE_MS + Math.round((Math.random() * 2 - 1) * LOOP_JITTER_MS);
+}
+
+async function wait(ms) {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const loop = process.argv.includes('--loop');
+  if (!loop) {
+    await runImageMaintenance({ vacuum: true });
+    return;
+  }
+
+  // The primary container always performs a foreground startup run. Delay the
+  // sidecar's first run so both containers do not immediately VACUUM the same
+  // database. Each later run receives independent ±1 hour jitter.
+  while (true) {
+    const delay = nextDelay();
+    logger.info(`[image-maintenance] next background run in ${Math.round(delay / 60000)} minutes`);
+    await wait(delay);
+    try {
+      await runImageMaintenance({ vacuum: true });
+    } catch (err) {
+      logger.error(`[image-maintenance] background run failed: ${err.stack || err.message}`);
+    }
+  }
+}
+
+main().catch(err => {
+  logger.error(`[image-maintenance] fatal: ${err.stack || err.message}`);
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,7 @@ import { logger }   from './logger.js';
 import { authenticate, userMgmtActive } from './middleware/auth.js';
 import { csrfProtect } from './middleware/csrf.js';
 import { makeRateLimiter } from './middleware/rate-limit.js';
+import { formatBytes, requestLogging, requestLogPath } from './middleware/request-logging.js';
 import { seedSmtpFromEnv } from './email.js';
 import { seedAiFromEnv } from './ai.js';
 import { seedOidcFromEnv } from './lib/oidc-env.js';
@@ -64,6 +65,10 @@ if (BASE_URL && !BASE_URL.startsWith('/')) {
 // Using a sub-router keeps `req.path` in middleware (e.g. csrf.js skip lists)
 // relative to the mount point so existing path checks keep working.
 const router = express.Router();
+
+// Register before body parsing so even malformed/oversized requests have a
+// method, route, duration, status, and observed/declared body size in the log.
+router.use(requestLogging);
 
 // Per-route JSON limits for endpoints that legitimately handle large payloads
 // (full data export/import, full-history sync push). Registered BEFORE the
@@ -118,17 +123,6 @@ router.use('/api/proxy', proxyRoutes);
 
 router.use(authenticate);   // attach req.user on every request
 router.use(csrfProtect);   // CSRF protection for cookie-based sessions
-
-// ── Request logging ────────────────────────────────────────────────────────
-router.use((req, res, next) => {
-  const start = Date.now();
-  res.on('finish', () => {
-    const ms   = Date.now() - start;
-    const lvl  = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
-    logger[lvl](`${req.method} ${req.path} → ${res.statusCode} (${ms}ms)`);
-  });
-  next();
-});
 
 // Prevent browser/proxy caching of all API responses
 router.use('/api', (req, res, next) => { res.set('Cache-Control', 'no-store'); next(); });
@@ -324,6 +318,23 @@ app.use(BASE_URL || '/', router);
 // ── Global error handler ───────────────────────────────────────────────────
 // eslint-disable-next-line no-unused-vars
 router.use((err, req, res, next) => {
+  if (err.type === 'entity.too.large') {
+    const declared = Number.parseInt(req.get('content-length') || '', 10);
+    const actual = Number.isFinite(err.length) ? err.length
+      : Number.isFinite(err.received) ? err.received
+        : declared;
+    logger.error(
+      `${req.method} ${requestLogPath(req)} — request body ${formatBytes(actual)} exceeds ${formatBytes(err.limit)} limit`
+    );
+    if (!res.headersSent) {
+      return res.status(413).json({
+        error: 'Request body too large',
+        size_bytes: Number.isFinite(actual) ? actual : null,
+        limit_bytes: err.limit,
+      });
+    }
+    return;
+  }
   logger.error(`${req.method} ${req.path} — ${err.stack || err.message}`);
   if (!res.headersSent) {
     res.status(err.status || 500).json({ error: err.message || 'Internal server error' });

--- a/server/index.js
+++ b/server/index.js
@@ -367,13 +367,7 @@ app.listen(PORT, () => {
     logger.warn(`[off-local-scheduler] failed to start: ${e.message}`);
   });
 
-  // (Boot-time image migration removed deliberately. Earlier versions ran a
-  // localizeImage pass over every food/meal row with an http(s) img_url on
-  // every server start, but isExternalUrl() matched the server's OWN host
-  // too, so the loop kept re-downloading the same files from itself,
-  // assigning fresh filenames and orphaning every diary snapshot that still
-  // pointed at the previous name. The proper fix is upstream: strip full
-  // server URLs back to relative /uploads/ paths at write time in
-  // _stripResolvedImgUrl + _stripCachedPaths so they never enter the
-  // foods/meals table in the first place. Don't reintroduce this loop.)
+  // Inline data-URL migration is intentionally handled by docker-entrypoint.sh
+  // before this process starts. Do not add the old http(s) image migration
+  // loop here: it re-downloaded this server's own /uploads files on restart.
 });

--- a/server/lib/image-localizer.js
+++ b/server/lib/image-localizer.js
@@ -77,11 +77,13 @@ async function _hostnameResolvesPrivate(hostname) {
  * arbitrary content into /uploads/ via a fake MIME-typed data URL.
  *
  * Returns the (possibly updated) img_url. On any failure, returns the
- * original — never throws.
+ * original — never throws. Database write paths must use
+ * localizeImageForStorage() below, which turns a failed inline-image
+ * localization into a 422 instead of allowing base64 bytes into SQLite.
  */
 export async function localizeImage(img_url) {
   if (!img_url) return img_url;
-  if (img_url.startsWith('data:')) return await _localizeDataUrl(img_url);
+  if (/^data:/i.test(img_url)) return await _localizeDataUrl(img_url);
   if (!img_url.startsWith('http')) return img_url; // Already local
 
   // Check if it's already on our server
@@ -134,8 +136,7 @@ export async function localizeImage(img_url) {
       return img_url;
     }
 
-    fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-    fs.writeFileSync(filePath, buffer);
+    writeImageFileAtomically(filePath, buffer);
 
     const localPath = `/uploads/${filename}`;
     logger.debug(`[image-localizer] Downloaded: ${img_url.substring(0, 60)} → ${localPath}`);
@@ -152,9 +153,9 @@ export async function localizeImage(img_url) {
  * the decoded bytes so the declared MIME type can't be lied about.
  *
  * On invalid format / bad base64 / unrecognised image / oversize / disk
- * write failure: returns the original data URL untouched so the caller's
- * UPDATE/INSERT still succeeds — the storage bloat is recoverable on the
- * next save once the user fixes the offending image. Never throws.
+ * write failure: returns the original data URL untouched. This lets the
+ * maintenance job report and retry legacy rows; database write routes use
+ * localizeImageForStorage() and reject the request instead. Never throws.
  */
 async function _localizeDataUrl(dataUrl) {
   // Expected shape: data:image/<subtype>;base64,<base64-payload>
@@ -187,12 +188,14 @@ async function _localizeDataUrl(dataUrl) {
   // Hash the bytes — same image saved twice ends up under the same
   // filename, which avoids stray /uploads/ duplicates when a user
   // re-saves a food whose image hasn't changed.
-  const hash = crypto.createHash('md5').update(buf).digest('hex').slice(0, 12);
-  const filename = `${Date.now()}-${hash}${ext}`;
+  const hash = crypto.createHash('sha256').update(buf).digest('hex').slice(0, 24);
+  // Content-addressed naming makes repeated sync pushes and maintenance runs
+  // idempotent. The former timestamp prefix created a new file for identical
+  // bytes every time despite the hash in its name.
+  const filename = `image-${hash}${ext}`;
   const filePath = path.join(UPLOADS_DIR, filename);
   try {
-    fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-    fs.writeFileSync(filePath, buf);
+    writeImageFileAtomically(filePath, buf);
   } catch (e) {
     logger.warn(`[image-localizer] Disk write failed for data URL: ${e.message}`);
     return dataUrl;
@@ -200,6 +203,69 @@ async function _localizeDataUrl(dataUrl) {
   const localPath = `/uploads/${filename}`;
   logger.debug(`[image-localizer] Inlined data URL → ${localPath} (${detected}, ${buf.length}b)`);
   return localPath;
+}
+
+/**
+ * Persistable variant used by every food/meal database writer.
+ *
+ * External URLs deliberately remain usable when downloading them fails, but
+ * inline data URLs must either become /uploads/ paths or fail the request.
+ * Keeping localizeImage() non-throwing is useful to the boot-time repair job,
+ * which needs to continue past a damaged legacy row.
+ */
+export async function localizeImageForStorage(imgUrl, context = 'image') {
+  if (!imgUrl) return imgUrl;
+  const isDataUrl = /^data:/i.test(imgUrl);
+  const localized = isExternalUrl(imgUrl) || isDataUrl
+    ? await localizeImage(imgUrl)
+    : imgUrl;
+  if (typeof localized === 'string' && /^data:/i.test(localized)) {
+    const err = new Error(`Could not store ${context}: inline image localization failed`);
+    err.status = 422;
+    throw err;
+  }
+  return localized;
+}
+
+/**
+ * Write through a same-directory temporary file and atomically rename it.
+ * A crash can leave an unreferenced .tmp file, but never a truncated final
+ * image. Content-addressed destinations are byte-checked before reuse; a
+ * stale/truncated file from an older version is repaired atomically.
+ */
+export function writeImageFileAtomically(filePath, buffer) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  if (fs.existsSync(filePath)) {
+    try {
+      const existing = fs.readFileSync(filePath);
+      if (existing.equals(buffer)) return false;
+      logger.warn(`[image-localizer] Existing image differs; replacing atomically: ${path.basename(filePath)}`);
+    } catch (e) {
+      logger.warn(`[image-localizer] Could not verify existing image; replacing atomically: ${e.message}`);
+    }
+  }
+
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`
+  );
+  let fd;
+  try {
+    fd = fs.openSync(tempPath, 'wx', 0o644);
+    fs.writeFileSync(fd, buffer);
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(tempPath, filePath);
+    return true;
+  } catch (e) {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch {}
+    }
+    try { fs.unlinkSync(tempPath); } catch {}
+    throw e;
+  }
 }
 
 /**
@@ -223,7 +289,7 @@ function _guessExtension(url) {
  */
 export function isExternalUrl(url) {
   if (!url) return false;
-  if (url.startsWith('data:image/')) return true;
+  if (/^data:image\//i.test(url)) return true;
   if (!url.startsWith('http')) return false;
   // A URL is "external" only if it does NOT point at our own /uploads/
   // directory. Earlier versions returned true for ANY http URL, which made

--- a/server/lib/image-maintenance.js
+++ b/server/lib/image-maintenance.js
@@ -1,0 +1,212 @@
+import crypto from 'crypto';
+import fs from 'fs';
+
+import db from '../db.js';
+import { logger } from '../logger.js';
+import { localizeImage } from './image-localizer.js';
+import {
+  dataUrlDecodedBytes,
+  localizeInlineSnapshotImages,
+} from './inline-images.js';
+
+const LOCK_KEY = '_image_maintenance_lease';
+const LOCK_MAX_MS = 4 * 60 * 60 * 1000;
+db.pragma('busy_timeout = 30000');
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return 'unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+function databaseBytes() {
+  const dbPath = process.env.DB_PATH || './nutritrace.db';
+  try {
+    return fs.statSync(dbPath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function acquireLease() {
+  const token = crypto.randomUUID();
+  const now = Date.now();
+  const value = JSON.stringify({ token, expiresAt: now + LOCK_MAX_MS });
+
+  const transaction = db.transaction(() => {
+    const row = db.prepare('SELECT value FROM app_config WHERE key = ?').get(LOCK_KEY);
+    if (row?.value) {
+      try {
+        const existing = JSON.parse(row.value);
+        if (Number(existing.expiresAt) > now) return false;
+      } catch {
+        // Invalid/stale lease value is safe to replace.
+      }
+    }
+    db.prepare(
+      `INSERT INTO app_config (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+    ).run(LOCK_KEY, value);
+    return true;
+  });
+
+  return transaction.immediate() ? { token, value } : null;
+}
+
+function releaseLease(lease) {
+  if (!lease) return;
+  db.prepare('DELETE FROM app_config WHERE key = ? AND value = ?').run(LOCK_KEY, lease.value);
+}
+
+async function localizeCanonicalRows(table, summary) {
+  // Include soft-deleted rows deliberately. Their image reference is part of
+  // the tombstone and may be needed for restore, deleted-item lookup, and
+  // future reference-counted garbage collection.
+  const rows = db.prepare(
+    `SELECT id, img_url, deleted_at FROM ${table}
+     WHERE img_url LIKE 'data:image/%' ORDER BY id`
+  ).all();
+  const update = db.prepare(
+    `UPDATE ${table} SET img_url = ?, updated_at = datetime('now') WHERE id = ?`
+  );
+
+  for (const row of rows) {
+    const decodedBytes = dataUrlDecodedBytes(row.img_url);
+    const localized = await localizeImage(row.img_url);
+    if (!localized || localized.startsWith('data:')) {
+      summary.failures++;
+      logger.warn(`[image-maintenance] failed ${table} id=${row.id} inline=${formatBytes(row.img_url.length)} decoded=${formatBytes(decodedBytes)}`);
+      continue;
+    }
+    update.run(localized, row.id);
+    summary.localized++;
+    summary.inlineCharsRemoved += row.img_url.length;
+    summary.decodedBytes += decodedBytes;
+    logger.debug(
+      `[image-maintenance] localized ${table} id=${row.id} deleted=${row.deleted_at ? 'yes' : 'no'} ` +
+      `inline=${formatBytes(row.img_url.length)} decoded=${formatBytes(decodedBytes)} path=${localized}`
+    );
+  }
+}
+
+async function localizeSnapshotRows(table, summary) {
+  const rows = db.prepare(
+    `SELECT id, items FROM ${table} WHERE items LIKE '%data:image/%' ORDER BY id`
+  ).all();
+  const update = db.prepare(
+    `UPDATE ${table} SET items = ?, updated_at = datetime('now') WHERE id = ?`
+  );
+
+  for (const row of rows) {
+    let items;
+    try {
+      items = JSON.parse(row.items || '[]');
+    } catch (err) {
+      summary.failures++;
+      logger.warn(`[image-maintenance] invalid ${table}.items JSON id=${row.id}: ${err.message}`);
+      continue;
+    }
+
+    let rowImages = 0;
+    let rowDecoded = 0;
+    let rowFailures = 0;
+    const migrated = await localizeInlineSnapshotImages(
+      items,
+      localizeImage,
+      ({ source, localized, itemId, key, success }) => {
+        const decodedBytes = dataUrlDecodedBytes(source);
+        if (!success) {
+          rowFailures++;
+          summary.failures++;
+          logger.warn(
+            `[image-maintenance] failed snapshot table=${table} row_id=${row.id} ` +
+            `item_id=${itemId ?? 'unknown'} key=${key} inline=${formatBytes(source.length)} ` +
+            `decoded=${formatBytes(decodedBytes)}`
+          );
+          return;
+        }
+        rowImages += 1;
+        rowDecoded += decodedBytes;
+        logger.debug(
+          `[image-maintenance] localized snapshot table=${table} row_id=${row.id} ` +
+          `item_id=${itemId ?? 'unknown'} key=${key} inline=${formatBytes(source.length)} ` +
+          `decoded=${formatBytes(decodedBytes)} path=${localized}`
+        );
+      }
+    );
+    if (!migrated.changed) {
+      if (rowFailures === 0) {
+        summary.failures++;
+        logger.warn(`[image-maintenance] could not localize embedded images in ${table} id=${row.id}`);
+      }
+      continue;
+    }
+
+    const serialized = JSON.stringify(migrated.value);
+    update.run(serialized, row.id);
+    summary.snapshotRows++;
+    summary.snapshotImages += rowImages;
+    summary.inlineCharsRemoved += Math.max(0, row.items.length - serialized.length);
+    summary.decodedBytes += rowDecoded;
+    logger.debug(
+      `[image-maintenance] localized snapshots ${table} id=${row.id} images=${rowImages} failures=${rowFailures} ` +
+      `before=${formatBytes(row.items.length)} after=${formatBytes(serialized.length)} decoded=${formatBytes(rowDecoded)}`
+    );
+  }
+}
+
+export async function runImageMaintenance({ vacuum = true } = {}) {
+  const lease = acquireLease();
+  if (!lease) {
+    logger.info('[image-maintenance] skipped: another maintenance process holds the lease');
+    return { skipped: true };
+  }
+
+  const startedAt = Date.now();
+  const beforeBytes = databaseBytes();
+  const summary = {
+    localized: 0,
+    snapshotRows: 0,
+    snapshotImages: 0,
+    failures: 0,
+    inlineCharsRemoved: 0,
+    decodedBytes: 0,
+  };
+  logger.info(`[image-maintenance] start database=${formatBytes(beforeBytes)} vacuum=${vacuum ? 'yes' : 'no'}`);
+
+  try {
+    await localizeCanonicalRows('foods', summary);
+    await localizeCanonicalRows('meals', summary);
+    await localizeSnapshotRows('meals', summary);
+    await localizeSnapshotRows('diary', summary);
+
+    // VACUUM exclusively locks and rewrites the database. Only pay that cost
+    // when this run actually removed inline data from SQLite.
+    const shouldVacuum = vacuum && (summary.localized > 0 || summary.snapshotRows > 0);
+    if (shouldVacuum) {
+      logger.info('[image-maintenance] VACUUM start');
+      db.pragma('wal_checkpoint(TRUNCATE)');
+      db.exec('VACUUM');
+      // In WAL mode VACUUM may leave the compacted database pages in the WAL
+      // until the next checkpoint. Materialize and truncate them now so the
+      // finish summary reports the actual compacted main-file size.
+      db.pragma('wal_checkpoint(TRUNCATE)');
+      logger.info('[image-maintenance] VACUUM finish');
+    } else if (vacuum) {
+      logger.info('[image-maintenance] VACUUM skipped: no inline images were localized');
+    }
+
+    const afterBytes = databaseBytes();
+    logger.info(
+      `[image-maintenance] finish localized=${summary.localized} snapshot_rows=${summary.snapshotRows} ` +
+      `snapshot_images=${summary.snapshotImages} failures=${summary.failures} ` +
+      `inline_removed=${formatBytes(summary.inlineCharsRemoved)} decoded=${formatBytes(summary.decodedBytes)} ` +
+      `database_before=${formatBytes(beforeBytes)} database_after=${formatBytes(afterBytes)} ` +
+      `duration_ms=${Date.now() - startedAt}`
+    );
+    return { ...summary, beforeBytes, afterBytes, vacuumed: shouldVacuum, skipped: false };
+  } finally {
+    releaseLease(lease);
+  }
+}

--- a/server/lib/inline-images.js
+++ b/server/lib/inline-images.js
@@ -1,0 +1,82 @@
+/**
+ * Helpers for image-bearing JSON snapshots (diary items, recipe ingredients).
+ *
+ * Canonical food/meal images belong in /uploads. Snapshot JSON may retain a
+ * small /uploads/... reference, but must never retain the image bytes as a
+ * data URL. These helpers recurse because split recipes can nest food items.
+ */
+
+const IMAGE_KEYS = new Set(['imgUrl', 'img_url']);
+
+export function dataUrlDecodedBytes(value) {
+  if (typeof value !== 'string') return 0;
+  const match = /^data:image\/[a-zA-Z0-9.+-]+;base64,(.+)$/i.exec(value);
+  if (!match) return 0;
+  try {
+    return Buffer.from(match[1], 'base64').length;
+  } catch {
+    return 0;
+  }
+}
+
+export function stripInlineSnapshotImages(value) {
+  let changed = false;
+
+  function visit(node) {
+    if (Array.isArray(node)) return node.map(visit);
+    if (!node || typeof node !== 'object') return node;
+
+    const out = {};
+    for (const [key, item] of Object.entries(node)) {
+      if (IMAGE_KEYS.has(key) && typeof item === 'string' && item.startsWith('data:image/')) {
+        out[key] = '';
+        changed = true;
+      } else {
+        out[key] = visit(item);
+      }
+    }
+    return out;
+  }
+
+  const result = visit(value);
+  return changed ? result : value;
+}
+
+export async function localizeInlineSnapshotImages(value, localize, onResult) {
+  let changed = false;
+
+  async function visit(node) {
+    if (Array.isArray(node)) return Promise.all(node.map(visit));
+    if (!node || typeof node !== 'object') return node;
+
+    const entries = await Promise.all(Object.entries(node).map(async ([key, item]) => {
+      if (IMAGE_KEYS.has(key) && typeof item === 'string' && item.startsWith('data:image/')) {
+        const localized = await localize(item);
+        if (typeof localized === 'string' && !localized.startsWith('data:')) {
+          changed = true;
+          onResult?.({
+            key,
+            source: item,
+            localized,
+            itemId: node.id ?? node.server_id ?? node.client_id ?? null,
+            success: true,
+          });
+          return [key, localized];
+        }
+        onResult?.({
+          key,
+          source: item,
+          localized: null,
+          itemId: node.id ?? node.server_id ?? node.client_id ?? null,
+          success: false,
+        });
+        return [key, item];
+      }
+      return [key, await visit(item)];
+    }));
+    return Object.fromEntries(entries);
+  }
+
+  const result = await visit(value);
+  return { value: changed ? result : value, changed };
+}

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,8 +1,9 @@
 /**
  * Simple structured logger — outputs to stdout/stderr with timestamps.
- * Set LOG_LEVEL env var to 'error' | 'warn' | 'info' | 'debug' (default: info)
+ * Set LOG_LEVEL env var to 'error' | 'warn' | 'info' | 'debug' | 'trace'
+ * (default: info)
  */
-const LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const LEVELS = { error: 0, warn: 1, info: 2, debug: 3, trace: 4 };
 const LOG_LEVEL = LEVELS[process.env.LOG_LEVEL] ?? LEVELS.info;
 
 function log(level, ...args) {
@@ -18,6 +19,7 @@ export const logger = {
   warn:  (...a) => log('warn',  ...a),
   info:  (...a) => log('info',  ...a),
   debug: (...a) => log('debug', ...a),
+  trace: (...a) => log('trace', ...a),
 };
 
 /** Wraps an async Express route handler so thrown errors reach the error middleware. */

--- a/server/middleware/request-logging.js
+++ b/server/middleware/request-logging.js
@@ -1,0 +1,89 @@
+import { logger } from '../logger.js';
+
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const REDACTED_KEY = /(authorization|cookie|password|passwd|secret|token|api[_-]?key|client[_-]?secret|recovery|credential)/i;
+const DEFAULT_TRACE_BODY_MAX_BYTES = 32 * 1024;
+
+function byteCount(value) {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function redactedBody(value, seen = new WeakSet()) {
+  if (typeof value === 'string' && value.startsWith('data:')) {
+    return `[data URL: ${byteCount(value)} bytes]`;
+  }
+  if (value == null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+
+  if (Array.isArray(value)) return value.map(item => redactedBody(item, seen));
+
+  const settingCarriesSecret = typeof value.key === 'string' && REDACTED_KEY.test(value.key);
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => {
+    if (REDACTED_KEY.test(key)) return [key, '[REDACTED]'];
+    if (settingCarriesSecret && key === 'value') return [key, '[REDACTED]'];
+    return [key, redactedBody(item, seen)];
+  }));
+}
+
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return 'unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export function formatTraceBody(body, maxBytes = DEFAULT_TRACE_BODY_MAX_BYTES) {
+  let json;
+  try {
+    json = JSON.stringify(redactedBody(body));
+  } catch (err) {
+    return `[unserializable body: ${err.message}]`;
+  }
+  if (byteCount(json) <= maxBytes) return json;
+
+  const suffix = `… [truncated; serialized body ${formatBytes(byteCount(json))}]`;
+  return Buffer.from(json).subarray(0, Math.max(0, maxBytes - byteCount(suffix))).toString('utf8') + suffix;
+}
+
+export function requestLogPath(req) {
+  return `${req.baseUrl || ''}${req.path || ''}` || '/';
+}
+
+function traceBodyLimit() {
+  const configured = Number.parseInt(process.env.TRACE_BODY_MAX_BYTES || '', 10);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_TRACE_BODY_MAX_BYTES;
+}
+
+/**
+ * Register before body parsers so rejected requests are still measured/logged.
+ * The data listener observes the same chunks as body-parser; it does not retain
+ * them, which keeps the body-size protection effective.
+ */
+export function requestLogging(req, res, next) {
+  const startedAt = Date.now();
+  const method = req.method;
+  // Exclude query strings: OAuth callbacks and other endpoints can carry
+  // authorization codes/tokens in the URL.
+  const requestPath = requestLogPath(req);
+  const declaredBytes = Number.parseInt(req.get('content-length') || '', 10);
+  let receivedBytes = 0;
+
+  req.on('data', chunk => { receivedBytes += chunk.length; });
+
+  res.on('finish', () => {
+    const status = res.statusCode;
+    const level = status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
+    const measuredBytes = receivedBytes || (Number.isFinite(declaredBytes) ? declaredBytes : 0);
+    const size = BODY_METHODS.has(method) ? `, body ${formatBytes(measuredBytes)}` : '';
+    logger[level](`${method} ${requestPath} → ${status} (${Date.now() - startedAt}ms${size})`);
+
+    if (BODY_METHODS.has(method) && req.body !== undefined) {
+      logger.trace(`${method} ${requestPath} body: ${formatTraceBody(req.body, traceBodyLimit())}`);
+    }
+  });
+
+  next();
+}

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import db from '../db.js';
 import { wrap } from '../logger.js';
 import { requireAuth, userMgmtActive } from '../middleware/auth.js';
+import { localizeImageForStorage } from '../lib/image-localizer.js';
+import { stripInlineSnapshotImages } from '../lib/inline-images.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -32,9 +34,22 @@ router.delete('/', wrap((req, res) => {
 }));
 
 // Bulk import — accepts NutriTrace backup format (foodList/meals/recipes/diary)
-router.post('/import', wrap((req, res) => {
+router.post('/import', wrap(async (req, res) => {
   const { foodList = [], meals = [], recipes = [], diary = [], activity = [], fasts = [] } = req.body;
   const u = uid(req);
+  const localizedFoods = await Promise.all(foodList.map(async f => ({
+    ...f,
+    _localizedImg: (f.imgUrl || f.img_url)
+      ? await localizeImageForStorage(f.imgUrl || f.img_url, 'imported food image')
+      : null,
+  })));
+  const localizedMeals = await Promise.all([...meals, ...recipes].map(async m => ({
+    ...m,
+    _localizedImg: (m.imgUrl || m.img_url)
+      ? await localizeImageForStorage(m.imgUrl || m.img_url, 'imported meal image')
+      : null,
+    _isRecipe: recipes.includes(m),
+  })));
 
   // updated_at must be set explicitly: the differential sync engine filters
   // foods/meals by `updated_at >= since`, and rows inserted without it would
@@ -75,12 +90,12 @@ router.post('/import', wrap((req, res) => {
   );
 
   const run = db.transaction(() => {
-    for (const f of foodList) {
+    for (const f of localizedFoods) {
       insFood.run(
         u, f.name || '', f.brand || null,
         JSON.stringify(f.nutrition || {}),
         f.portion ?? 100, f.unit || 'g',
-        f.imgUrl || f.img_url || null,
+        f._localizedImg,
         f.notes || null,
         (f.categories && f.categories[0]) || f.category || null,
         f.barcode || null,
@@ -94,13 +109,13 @@ router.post('/import', wrap((req, res) => {
         f.density_g_ml != null ? Number(f.density_g_ml) : null
       );
     }
-    for (const m of [...meals, ...recipes]) {
+    for (const m of localizedMeals) {
       insMeal.run(
         u, m.name || '', JSON.stringify(m.nutrition || {}),
-        JSON.stringify(m.items || []),
-        m.imgUrl || m.img_url || null,
+        JSON.stringify(stripInlineSnapshotImages(m.items || [])),
+        m._localizedImg,
         m.notes || null,
-        recipes.includes(m) ? 1 : 0,
+        m._isRecipe ? 1 : 0,
         m.portion ?? 100, m.unit || 'g',
         m.servings != null ? Math.max(1, parseInt(m.servings) || 1) : null,
         m.visibility || 'private',
@@ -114,7 +129,7 @@ router.post('/import', wrap((req, res) => {
       if (!e.date) continue;
       insDiary.run(
         u, e.date,
-        JSON.stringify(e.items || []),
+        JSON.stringify(stripInlineSnapshotImages(e.items || [])),
         JSON.stringify(e.bodyStats || e.body_stats || {}),
         JSON.stringify(e.water || []),
         (typeof e.notes === 'string' && e.notes.trim()) ? e.notes : null

--- a/server/routes/diary.js
+++ b/server/routes/diary.js
@@ -3,6 +3,7 @@ import db from '../db.js';
 import { wrap } from '../logger.js';
 import { requireAuth, userMgmtActive } from '../middleware/auth.js';
 import { freshenItemImages } from '../lib/diary-helpers.js';
+import { stripInlineSnapshotImages } from '../lib/inline-images.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -43,22 +44,9 @@ router.get('/:date', wrap((req, res) => {
 // at read time with the food/meal's current image, so the stored snapshot
 // is effectively unused for display. Dropping the data URL on store is
 // pure waste-reduction with no behavior change.
-function _stripDataUrlImages(items) {
-  if (!Array.isArray(items)) return items;
-  let changed = false;
-  const out = items.map(it => {
-    if (it && typeof it.imgUrl === 'string' && it.imgUrl.startsWith('data:')) {
-      changed = true;
-      return { ...it, imgUrl: '' };
-    }
-    return it;
-  });
-  return changed ? out : items;
-}
-
 router.put('/:date', wrap((req, res) => {
   const { body_stats, water, notes } = req.body;
-  const items = _stripDataUrlImages(req.body.items);
+  const items = stripInlineSnapshotImages(req.body.items);
   const notesVal = (typeof notes === 'string' && notes.trim()) ? notes : null;
   const u = uid(req);
   const itemsJson = JSON.stringify(items || []);
@@ -127,25 +115,17 @@ router.delete('/:date', wrap((req, res) => {
   res.json({ ok: true });
 }));
 
-// Fix any Capacitor cached paths that leaked into diary items
-function fixCachedPaths(items) {
+// Cached device-local paths are not server image references. Older versions
+// guessed an /uploads/ path from the cache filename, coupling correctness to
+// a filename regex and occasionally inventing paths that did not exist.
+function scrubDeviceLocalImagePaths(items) {
   if (!Array.isArray(items)) return items;
   let changed = false;
   const fixed = items.map(i => {
     if (!i.imgUrl) return i;
-    // Fix Capacitor cached paths — only restore to /uploads/ when the basename
-    // matches the server's localized image-naming pattern (timestamp-md5.ext,
-    // see server/lib/image-localizer.js). Cached externally-proxied images use
-    // the source URL basename (e.g. 'front.en.6.400.jpg' from OFF), which does
-    // not correspond to any /uploads/ file. Prepending /uploads/ would point
-    // every OFF-imported item at the same (or missing) /uploads/<basename>.
     if (i.imgUrl.includes('_capacitor_file_') || i.imgUrl.includes('/image_cache/')) {
-      const filename = i.imgUrl.split('/').pop();
       changed = true;
-      if (filename && /^\d{10,}-[0-9a-f]{8,16}\.\w+$/i.test(filename)) {
-        return { ...i, imgUrl: '/uploads/' + filename };
-      }
-      return { ...i, imgUrl: '' }; // basename doesn't match server format
+      return { ...i, imgUrl: '' };
     }
     // Fix mangled proxy URLs (e.g., /uploads/proxy)
     if (i.imgUrl === '/uploads/proxy' || i.imgUrl === '/uploads/proxy?url=') {
@@ -169,7 +149,7 @@ function parse(row) {
   const items = JSON.parse(row.items || '[]');
   return {
     ...row,
-    items:      freshenItemImages(fixCachedPaths(items)),
+    items:      freshenItemImages(scrubDeviceLocalImagePaths(items)),
     body_stats: JSON.parse(row.body_stats || '{}'),
     water:      JSON.parse(row.water      || '[]'),
     notes:      row.notes || '',

--- a/server/routes/foods.js
+++ b/server/routes/foods.js
@@ -3,7 +3,7 @@ import db from '../db.js';
 import { wrap } from '../logger.js';
 import { requireAuth, userMgmtActive } from '../middleware/auth.js';
 import { sharingEnabled, canRead as _canRead } from '../lib/sharing.js';
-import { localizeImage, isExternalUrl } from '../lib/image-localizer.js';
+import { localizeImageForStorage } from '../lib/image-localizer.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -95,8 +95,9 @@ router.post('/', wrap(async (req, res) => {
     ).get(...args);
     if (existing) return res.status(200).json(parse(existing));
   }
-  // Download external images to /uploads/ for self-hosting
-  const localImg = isExternalUrl(img_url) ? await localizeImage(img_url) : (img_url || null);
+  // Inline data URLs must become /uploads/ paths or the request fails with
+  // 422; they must never be persisted directly in SQLite.
+  const localImg = img_url ? await localizeImageForStorage(img_url, 'food image') : null;
   const result = db.prepare(
     `INSERT INTO foods (user_id, name, brand, nutrition, portion, unit, img_url, notes, category, barcode, visibility, source_id, nutrition_basis, alt_units, density_g_ml, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
@@ -126,7 +127,7 @@ router.put('/:id', wrap(async (req, res) => {
   // used below for nutrition_basis / alt_units / density_g_ml.
   const localImg = img_url === undefined
     ? existing.img_url
-    : ((img_url && isExternalUrl(img_url)) ? await localizeImage(img_url) : (img_url || null));
+    : (img_url ? await localizeImageForStorage(img_url, 'food image') : null);
   const fav = favorite != null ? (favorite ? 1 : 0) : existing.favorite;
   // For the OFF metadata: undefined → keep existing, null → explicit clear,
   // any other value → normalize-and-store. Lets the client patch one field
@@ -198,7 +199,7 @@ router.patch('/:id/share', wrap((req, res) => {
 }));
 
 // ── POST /:id/copy — clone a shared food into caller's catalogue ──────────
-router.post('/:id/copy', wrap((req, res) => {
+router.post('/:id/copy', wrap(async (req, res) => {
   const u = uid(req);
   if (!sharingEnabled()) return res.status(403).json({ error: 'Sharing is not enabled on this instance.' });
   const food = db.prepare('SELECT * FROM foods WHERE id = ?').get(req.params.id);
@@ -212,11 +213,17 @@ router.post('/:id/copy', wrap((req, res) => {
     if (existing) return res.json(parse(db.prepare('SELECT * FROM foods WHERE id = ?').get(existing.id)));
   }
 
+  // Normally the source is already localized. Keep the copy path strict as
+  // well so a legacy inline row cannot be duplicated if startup maintenance
+  // could not repair it.
+  const localImg = food.img_url
+    ? await localizeImageForStorage(food.img_url, 'copied food image')
+    : null;
   const result = db.prepare(
     `INSERT INTO foods (user_id, name, brand, nutrition, portion, unit, img_url, notes, category, barcode, visibility, source_id, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'private', ?, datetime('now'))`
   ).run(u, food.name, food.brand, food.nutrition, food.portion, food.unit,
-    food.img_url, food.notes, food.category, food.barcode, food.id);
+    localImg, food.notes, food.category, food.barcode, food.id);
   res.status(201).json(parse(db.prepare('SELECT * FROM foods WHERE id = ?').get(result.lastInsertRowid)));
 }));
 

--- a/server/routes/full-backup.js
+++ b/server/routes/full-backup.js
@@ -10,6 +10,11 @@ import { logger } from '../logger.js';
 import { seedSmtpFromEnv } from '../email.js';
 import { seedAiFromEnv } from '../ai.js';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import {
+  localizeImageForStorage,
+  writeImageFileAtomically,
+} from '../lib/image-localizer.js';
+import { localizeInlineSnapshotImages } from '../lib/inline-images.js';
 
 const router = express.Router();
 router.use(requireAuth);
@@ -188,8 +193,39 @@ const upload = multer({
   limits: { fileSize: _backupMaxMb * 1024 * 1024 },
 });
 
-function restoreFromZip(zip) {
+async function localizeRestoreSnapshot(raw, context) {
+  if (!raw || (typeof raw === 'string' && !raw.includes('data:image/'))) return raw;
+  const wasSerialized = typeof raw === 'string';
+  const value = wasSerialized ? JSON.parse(raw) : raw;
+  const localized = await localizeInlineSnapshotImages(
+    value,
+    source => localizeImageForStorage(source, context)
+  );
+  return wasSerialized ? JSON.stringify(localized.value) : localized.value;
+}
+
+async function restoreFromZip(zip) {
   const data = JSON.parse(zip.readAsText('database.json'));
+
+  // Normalize before the destructive restore transaction. A failed inline
+  // image therefore aborts the restore without replacing the current DB.
+  data.foods = await Promise.all((data.foods || []).map(async food => ({
+    ...food,
+    img_url: food.img_url
+      ? await localizeImageForStorage(food.img_url, `restored food image id=${food.id ?? 'unknown'}`)
+      : null,
+  })));
+  data.meals = await Promise.all((data.meals || []).map(async meal => ({
+    ...meal,
+    img_url: meal.img_url
+      ? await localizeImageForStorage(meal.img_url, `restored meal image id=${meal.id ?? 'unknown'}`)
+      : null,
+    items: await localizeRestoreSnapshot(meal.items, `restored meal snapshot id=${meal.id ?? 'unknown'}`),
+  })));
+  data.diary = await Promise.all((data.diary || []).map(async entry => ({
+    ...entry,
+    items: await localizeRestoreSnapshot(entry.items, `restored diary snapshot id=${entry.id ?? entry.date ?? 'unknown'}`),
+  })));
 
   db.transaction(() => {
     db.prepare('DELETE FROM password_reset_tokens').run();
@@ -364,8 +400,7 @@ function restoreFromZip(zip) {
     const data = entry.getData();
     totalBytes += data.length;
     if (totalBytes > MAX_BYTES) throw new Error(`Backup uncompressed size exceeds ${MAX_BYTES} bytes (zip-bomb defense)`);
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.writeFileSync(dest, data);
+    writeImageFileAtomically(dest, data);
   }
 
   // Re-apply env-var config so lock flags always reflect the current environment,
@@ -501,12 +536,12 @@ router.delete('/:name', requireAdmin, (req, res) => {
 });
 
 // ── POST /api/full-backup/:name/restore — restore from a server-side backup ─
-router.post('/:name/restore', requireAdmin, (req, res) => {
+router.post('/:name/restore', requireAdmin, async (req, res) => {
   const filename = path.basename(req.params.name);
   const filePath = path.join(BACKUPS_DIR, filename);
   if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'Not found' });
   try {
-    restoreFromZip(new AdmZip(filePath));
+    await restoreFromZip(new AdmZip(filePath));
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -514,10 +549,10 @@ router.post('/:name/restore', requireAdmin, (req, res) => {
 });
 
 // ── POST /api/full-backup/upload-restore — upload a ZIP and restore from it ─
-router.post('/upload-restore', requireAdmin, upload.single('backup'), (req, res) => {
+router.post('/upload-restore', requireAdmin, upload.single('backup'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
   try {
-    restoreFromZip(new AdmZip(req.file.path));
+    await restoreFromZip(new AdmZip(req.file.path));
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/routes/meals.js
+++ b/server/routes/meals.js
@@ -3,7 +3,8 @@ import db from '../db.js';
 import { wrap } from '../logger.js';
 import { requireAuth, userMgmtActive } from '../middleware/auth.js';
 import { sharingEnabled, canRead as _canRead } from '../lib/sharing.js';
-import { localizeImage, isExternalUrl } from '../lib/image-localizer.js';
+import { localizeImageForStorage } from '../lib/image-localizer.js';
+import { stripInlineSnapshotImages } from '../lib/inline-images.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -58,11 +59,11 @@ router.post('/', wrap(async (req, res) => {
   if (!name) return res.status(400).json({ error: 'Name required' });
   const u = uid(req);
   const vis = visibility || 'private';
-  const localImg = isExternalUrl(img_url) ? await localizeImage(img_url) : (img_url || null);
+  const localImg = img_url ? await localizeImageForStorage(img_url, 'meal image') : null;
   const result = db.prepare(
     `INSERT INTO meals (user_id, name, nutrition, items, img_url, notes, is_recipe, portion, unit, servings, visibility, source_id, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
-  ).run(u, name, JSON.stringify(nutrition || {}), JSON.stringify(items || []),
+  ).run(u, name, JSON.stringify(nutrition || {}), JSON.stringify(stripInlineSnapshotImages(items || [])),
     localImg, notes || null, is_recipe ? 1 : 0, portion ?? 100, unit || 'g',
     servings != null ? Math.max(1, parseInt(servings) || 1) : null,
     vis, source_id || null);
@@ -70,7 +71,7 @@ router.post('/', wrap(async (req, res) => {
 }));
 
 // ── PUT /:id ──────────────────────────────────────────────────────────────
-router.put('/:id', wrap((req, res) => {
+router.put('/:id', wrap(async (req, res) => {
   const u = uid(req);
   const existing = db.prepare('SELECT * FROM meals WHERE id = ?').get(req.params.id);
   if (!existing) return res.status(404).json({ error: 'Not found' });
@@ -86,14 +87,15 @@ router.put('/:id', wrap((req, res) => {
   // The old inline `img_url ?? existing.img_url` treated null as nullish and
   // preserved the existing image, so the MealEditor X-remove-photo button
   // silently failed to clear the photo on save. Parallel to the foods.js
-  // PUT fix for kilkalabs's report on #74 follow-up. Note: external-URL /
-  // data-URL localization on this route is a separate parity gap with the
-  // POST handler (line ~61) — out of scope for this fix.
-  const img = 'img_url' in req.body ? (img_url || null) : existing.img_url;
+  // PUT fix for kilkalabs's report on #74 follow-up. Keep image localization
+  // in parity with POST so inline image bytes cannot enter SQLite here.
+  const img = 'img_url' in req.body
+    ? (img_url ? await localizeImageForStorage(img_url, 'meal image') : null)
+    : existing.img_url;
   db.prepare(
     `UPDATE meals SET name=?, nutrition=?, items=?, img_url=?, notes=?, is_recipe=?, portion=?, unit=?, servings=?, visibility=?, favorite=?, updated_at=datetime('now') WHERE id=?`
   ).run(name ?? existing.name, JSON.stringify(nutrition ?? JSON.parse(existing.nutrition || '{}')),
-    JSON.stringify(items ?? JSON.parse(existing.items || '[]')), img,
+    JSON.stringify(stripInlineSnapshotImages(items ?? JSON.parse(existing.items || '[]'))), img,
     notes ?? existing.notes, is_recipe != null ? (is_recipe ? 1 : 0) : existing.is_recipe,
     portion ?? existing.portion, unit ?? existing.unit, srv,
     visibility ?? existing.visibility, fav, req.params.id);
@@ -151,7 +153,7 @@ router.patch('/:id/share', wrap((req, res) => {
 // Food items within the meal are handled client-side (foods have their own /copy endpoint).
 // We store items as embedded nutrition snapshots so the copy always works regardless of
 // whether the original food items are accessible to the new owner.
-router.post('/:id/copy', wrap((req, res) => {
+router.post('/:id/copy', wrap(async (req, res) => {
   const u = uid(req);
   if (!sharingEnabled()) return res.status(403).json({ error: 'Sharing is not enabled on this instance.' });
   const meal = db.prepare('SELECT * FROM meals WHERE id = ?').get(req.params.id);
@@ -165,10 +167,16 @@ router.post('/:id/copy', wrap((req, res) => {
     if (existing) return res.json(parse(db.prepare('SELECT * FROM meals WHERE id = ?').get(existing.id)));
   }
 
+  // Do not duplicate a legacy inline canonical image or embedded snapshot if
+  // startup maintenance could not repair the source row.
+  const localImg = meal.img_url
+    ? await localizeImageForStorage(meal.img_url, 'copied meal image')
+    : null;
+  const items = stripInlineSnapshotImages(JSON.parse(meal.items || '[]'));
   const result = db.prepare(
     `INSERT INTO meals (user_id, name, nutrition, items, img_url, notes, is_recipe, portion, unit, visibility, source_id, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'private', ?, datetime('now'))`
-  ).run(u, meal.name, meal.nutrition, meal.items, meal.img_url, meal.notes,
+  ).run(u, meal.name, meal.nutrition, JSON.stringify(items), localImg, meal.notes,
     meal.is_recipe, meal.portion, meal.unit, meal.id);
   res.status(201).json(parse(db.prepare('SELECT * FROM meals WHERE id = ?').get(result.lastInsertRowid)));
 }));

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -14,6 +14,8 @@ import { wrap } from '../logger.js';
 import { requireAuth, userMgmtActive } from '../middleware/auth.js';
 import { logger } from '../logger.js';
 import { isServerOnlyKey } from '../lib/server-only-keys.js';
+import { localizeImageForStorage } from '../lib/image-localizer.js';
+import { stripInlineSnapshotImages } from '../lib/inline-images.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -137,10 +139,41 @@ router.get('/pull', wrap((req, res) => {
 // Receives batch of changed records from the client.
 // Each record has: client_id, server_id (if previously synced), and the data fields.
 // Returns a mapping of client_id → server_id for newly created records.
-router.post('/push', wrap((req, res) => {
+router.post('/push', wrap(async (req, res) => {
   const u = uid(req);
-  const { foods = [], meals = [], diary = [], activity = [], fasts = [], wellness = [], settings = [], workouts = [] } = req.body;
+  const {
+    foods: incomingFoods = [],
+    meals: incomingMeals = [],
+    diary: incomingDiary = [],
+    activity = [], fasts = [], wellness = [], settings = [], workouts = [],
+  } = req.body;
   const result = { foods: [], meals: [], diary: [], activity: [], fasts: [], wellness: [], settings: [], workouts: [] };
+
+  // The native client is local-first, so newly-created food/meal images reach
+  // the server through sync rather than POST /api/foods. Normalize them before
+  // entering the synchronous SQLite transaction; otherwise base64 image bytes
+  // are persisted directly in foods.img_url / meals.img_url.
+  async function normalizeImage(record, kind) {
+    // Preserve tombstone image references. A future restore/deleted-item
+    // browser and image reference counter need the association to remain on
+    // the soft-deleted record until an explicit purge policy removes it.
+    if (!record.img_url) return record;
+    const localized = await localizeImageForStorage(
+      record.img_url,
+      `${kind} image for client item ${record.client_id ?? '(unknown)'}`
+    );
+    return { ...record, img_url: localized || null };
+  }
+
+  const foods = await Promise.all(incomingFoods.map(f => normalizeImage(f, 'food')));
+  const meals = await Promise.all(incomingMeals.map(async m => ({
+    ...(await normalizeImage(m, 'meal')),
+    items: stripInlineSnapshotImages(m.items),
+  })));
+  const diary = incomingDiary.map(d => ({
+    ...d,
+    items: stripInlineSnapshotImages(d.items),
+  }));
 
   // Normalize timestamp for comparison (strip T, Z, milliseconds)
   const norm = ts => ts ? ts.replace('T', ' ').replace('Z', '').replace(/\.\d+$/, '') : '';
@@ -157,7 +190,13 @@ router.post('/push', wrap((req, res) => {
       if (f.server_id && existing) {
         if (norm(f.updated_at) >= norm(existing.updated_at)) {
           if (f.deleted_at) {
-            db.prepare(`UPDATE foods SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(f.server_id);
+            db.prepare(
+              `UPDATE foods
+               SET img_url = COALESCE(?, img_url),
+                   deleted_at = datetime('now'),
+                   updated_at = datetime('now')
+               WHERE id = ?`
+            ).run(f.img_url || null, f.server_id);
           } else {
             db.prepare(
               `UPDATE foods SET name=?, brand=?, nutrition=?, portion=?, unit=?, img_url=?, notes=?, category=?, barcode=?, favorite=?, usage_count=MAX(usage_count, ?), last_used_at=MAX(COALESCE(last_used_at, ''), COALESCE(?, '')), nutrition_basis=?, alt_units=?, density_g_ml=?, updated_at=datetime('now') WHERE id=?`
@@ -200,7 +239,13 @@ router.post('/push', wrap((req, res) => {
       if (m.server_id && existing) {
         if (norm(m.updated_at) >= norm(existing.updated_at)) {
           if (m.deleted_at) {
-            db.prepare(`UPDATE meals SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(m.server_id);
+            db.prepare(
+              `UPDATE meals
+               SET img_url = COALESCE(?, img_url),
+                   deleted_at = datetime('now'),
+                   updated_at = datetime('now')
+               WHERE id = ?`
+            ).run(m.img_url || null, m.server_id);
           } else {
             db.prepare(
               `UPDATE meals SET name=?, nutrition=?, items=?, img_url=?, notes=?, is_recipe=?, portion=?, unit=?, servings=?, favorite=?, usage_count=MAX(usage_count, ?), last_used_at=MAX(COALESCE(last_used_at, ''), COALESCE(?, '')), updated_at=datetime('now') WHERE id=?`

--- a/src/lib/api-cached.js
+++ b/src/lib/api-cached.js
@@ -14,7 +14,13 @@ import {
   dbGetMeals, dbGetMeal, dbCreateMeal, dbUpdateMeal, dbDeleteMeal, dbCopyMeal, dbBumpMealUsage,
   dbGetDiaryDate, dbSaveDiaryDate, dbGetAllDiary,
 } from './db-native.js';
-import { getServerUrl, getAuthToken, resolveAssetUrl, apiUrl } from './platform.js';
+import {
+  getServerUrl,
+  getAuthToken,
+  resolveAssetUrl,
+  restoreCachedAssetUrl,
+  apiUrl,
+} from './platform.js';
 import { schedulePush } from './sync.js';
 
 function _headers() {
@@ -62,19 +68,10 @@ function _stripResolvedImgUrl(url) {
       return url.slice(idx);
     }
   } catch {}
-  // Capacitor cached path → only restore to /uploads/<filename> when the basename
-  // matches the server's localized image-naming pattern (timestamp-md5.ext, see
-  // server/lib/image-localizer.js). For anything else (e.g., a Capacitor cache
-  // of a proxied external URL, where the cached basename is the source URL's
-  // basename like 'front.en.6.400.jpg'), the basename does NOT correspond to
-  // any /uploads/ file and prepending /uploads/ would cross-pollinate images
-  // across foods that happen to share an OFF basename. Drop instead.
+  // Capacitor cache filenames are hashes and cannot be converted back by
+  // inspecting their basename. Recover the exact source from the cache map.
   if (url.includes('_capacitor_file_') || url.includes('/image_cache/')) {
-    const filename = url.split('/').pop();
-    if (filename && /^\d{10,}-[0-9a-f]{8,16}\.\w+$/i.test(filename)) {
-      return '/uploads/' + filename;
-    }
-    return ''; // can't recover original — clear rather than persist garbage
+    return restoreCachedAssetUrl(url) || '';
   }
   // Proxy URL (`/api/proxy?url=https://...`) → restore the inner URL.
   if (url.includes('/api/proxy?url=')) {

--- a/src/lib/diary-payload.js
+++ b/src/lib/diary-payload.js
@@ -1,0 +1,19 @@
+/**
+ * Diary items are snapshots of foods/meals, but inline images must not be part
+ * of that snapshot. A single base64 photo can be repeated for every occurrence
+ * of a food and make the full-row diary PUT exceed its body limit. The server
+ * resolves the current food/meal image when reading the diary, so dropping only
+ * inline data URLs does not affect display or the canonical image upload.
+ */
+export function stripInlineDiaryImages(items) {
+  if (!Array.isArray(items)) return items;
+  let changed = false;
+  const result = items.map(item => {
+    if (item && typeof item.imgUrl === 'string' && item.imgUrl.startsWith('data:')) {
+      changed = true;
+      return { ...item, imgUrl: '' };
+    }
+    return item;
+  });
+  return changed ? result : items;
+}

--- a/src/lib/diary-payload.js
+++ b/src/lib/diary-payload.js
@@ -6,14 +6,24 @@
  * inline data URLs does not affect display or the canonical image upload.
  */
 export function stripInlineDiaryImages(items) {
-  if (!Array.isArray(items)) return items;
   let changed = false;
-  const result = items.map(item => {
-    if (item && typeof item.imgUrl === 'string' && item.imgUrl.startsWith('data:')) {
-      changed = true;
-      return { ...item, imgUrl: '' };
+
+  function visit(value) {
+    if (Array.isArray(value)) return value.map(visit);
+    if (!value || typeof value !== 'object') return value;
+    const result = {};
+    for (const [key, item] of Object.entries(value)) {
+      if ((key === 'imgUrl' || key === 'img_url') &&
+          typeof item === 'string' && item.startsWith('data:image/')) {
+        result[key] = '';
+        changed = true;
+      } else {
+        result[key] = visit(item);
+      }
     }
-    return item;
-  });
+    return result;
+  }
+
+  const result = visit(items);
   return changed ? result : items;
 }

--- a/src/lib/image-cache-map.js
+++ b/src/lib/image-cache-map.js
@@ -1,0 +1,42 @@
+/**
+ * Recover the original image URL from the Android offline-cache map.
+ *
+ * The cache renames files to a hash, so their local basename has no useful
+ * relationship to the original server filename. The map is the source of
+ * truth: it stores original URL -> local URI entries.
+ */
+export function originalUrlForCachedImage(localUrl, imageMap) {
+  if (!localUrl || !imageMap || typeof imageMap !== 'object') return null;
+
+  const originals = Object.entries(imageMap)
+    .filter(([, cachedUrl]) => cachedUrl === localUrl)
+    .map(([original]) => original);
+  if (originals.length === 0) return null;
+
+  // Server uploads are stored under both relative and absolute keys. Prefer
+  // the portable relative form that works on the PWA and every other device.
+  const relativeUpload = originals.find(url => url.startsWith('/uploads/'));
+  if (relativeUpload) return relativeUpload;
+
+  const absoluteUpload = originals.find(url => {
+    if (!/^https?:\/\//i.test(url)) return false;
+    try { return new URL(url).pathname.includes('/uploads/'); } catch { return false; }
+  });
+  if (absoluteUpload) {
+    const pathname = new URL(absoluteUpload).pathname;
+    return pathname.slice(pathname.indexOf('/uploads/'));
+  }
+
+  // External images are also stored under a pathname-only key and their full
+  // URL. The full URL retains the host and is therefore the useful one.
+  const fullUrl = originals.find(url => /^https?:\/\//i.test(url));
+  const original = fullUrl || originals[0];
+
+  // A cached server proxy URL represents its inner external URL.
+  if (original.includes('/api/proxy?url=')) {
+    try {
+      return new URL(original, 'https://cache.invalid').searchParams.get('url') || original;
+    } catch {}
+  }
+  return original;
+}

--- a/src/lib/image-cache.js
+++ b/src/lib/image-cache.js
@@ -8,7 +8,7 @@
 
 import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Capacitor } from '@capacitor/core';
-import { getServerUrl, getAuthToken } from './platform.js';
+import { getServerUrl, getAuthToken, setImageMap } from './platform.js';
 
 const CACHE_DIR = 'image_cache';
 // Bump when the cache key derivation changes so existing users invalidate
@@ -222,6 +222,9 @@ export async function cacheAllImages(onProgress) {
 
   // Save updated map
   await _saveImageMap(imageMap);
+  // Keep the synchronous resolver and reverse lookup current immediately;
+  // otherwise newly cached images are only visible after the next app boot.
+  setImageMap(imageMap);
 
   console.log(`[image-cache] Done: ${downloaded} downloaded, ${failed} failed, ${Object.keys(imageMap).length} total cached`);
   return { total, downloaded, failed };
@@ -236,4 +239,3 @@ export async function resolveFromCache(serverUrl) {
   if (!_cachedMap) _cachedMap = await _loadImageMap();
   return _cachedMap[serverUrl] || null;
 }
-

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -6,6 +6,7 @@
  */
 
 import { Capacitor } from '@capacitor/core';
+import { originalUrlForCachedImage } from './image-cache-map.js';
 
 /**
  * True when running inside the Capacitor native shell (Android / iOS).
@@ -179,6 +180,14 @@ export async function loadImageMap() {
 /** Update the in-memory image map (called after image cache downloads) */
 export function setImageMap(map) {
   _imageMap = map || {};
+}
+
+/**
+ * Convert an Android offline-cache URI back to the exact image URL it was
+ * downloaded from. Returns null when the URI is not present in the cache map.
+ */
+export function restoreCachedAssetUrl(localUrl) {
+  return originalUrlForCachedImage(localUrl, _imageMap);
 }
 
 /**

--- a/src/lib/sync.js
+++ b/src/lib/sync.js
@@ -23,6 +23,7 @@ import {
   dbUpsertWorkoutFromServer, dbUpsertActivityFromServer,
   dbGetPendingWorkouts, dbSetWorkoutServerId,
 } from './db-native.js';
+import { stripInlineDiaryImages } from './diary-payload.js';
 import { writable } from 'svelte/store';
 
 /** Sync state — reactive store for UI */
@@ -176,7 +177,10 @@ async function pushChanges() {
       client_id: d.id,
       server_id: d.server_id || null,
       date: d.date,
-      items: d.items,
+      // Native diary rows can still contain the base64 image copied from a
+      // newly-created food. The food itself carries the canonical image; do
+      // not replicate it into the diary snapshot or the sync request.
+      items: stripInlineDiaryImages(d.items),
       body_stats: d.body_stats,
       water: d.water,
       updated_at: d.updated_at,

--- a/src/routes/FoodEditor.svelte
+++ b/src/routes/FoodEditor.svelte
@@ -134,7 +134,7 @@
 
   function cropEndDrag() { cropDragging = false; }
 
-  function confirmCrop() {
+  async function confirmCrop() {
     if (!cropImg || !cropBox) return;
     const scaleX = cropImg.naturalWidth  / cropImg.offsetWidth;
     const scaleY = cropImg.naturalHeight / cropImg.offsetHeight;
@@ -145,7 +145,10 @@
     const canvas = document.createElement('canvas');
     canvas.width = cw; canvas.height = ch;
     canvas.getContext('2d').drawImage(cropImg, cx, cy, cw, ch, 0, 0, cw, ch);
-    food.imgUrl = canvas.toDataURL('image/jpeg', 0.9);
+    // Cropping can still leave a multi-megapixel image when the selected
+    // source region is large. Run every result through the common 1920px
+    // fitter, just like the non-crop camera/gallery path.
+    food.imgUrl = await fitImageDataUrl(canvas.toDataURL('image/jpeg', 0.9));
     showCrop = false; cropSrc = '';
   }
 

--- a/src/routes/MealEditor.svelte
+++ b/src/routes/MealEditor.svelte
@@ -202,7 +202,7 @@
     cropBoxX = 20; cropBoxY = 20; cropBoxSize = 200;
   }
 
-  function confirmCrop() {
+  async function confirmCrop() {
     if (!cropImgEl) return;
     const canvas = document.createElement('canvas');
     const scaleX = cropImgEl.naturalWidth / cropImgEl.offsetWidth;
@@ -214,7 +214,10 @@
       cropBoxSize * scaleX, cropBoxSize * scaleY,
       0, 0, 300, 300
     );
-    photoPreviewUrl = canvas.toDataURL('image/jpeg', 0.85);
+    // Keep all capture paths behind the same size invariant. This crop is
+    // currently 300x300, so fitImageDataUrl is normally a no-op, but future
+    // crop-size changes cannot accidentally bypass fitting.
+    photoPreviewUrl = await fitImageDataUrl(canvas.toDataURL('image/jpeg', 0.85));
     cropOpen = false; cropSrc = '';
   }
 

--- a/src/stores/diary.js
+++ b/src/stores/diary.js
@@ -2,7 +2,7 @@ import { writable, derived } from 'svelte/store';
 import { NtApi } from '../lib/api.js';
 import { Nutrition } from '../lib/nutrition.js';
 import { localDateStr, DB } from '../lib/db.js';
-import { resolveAssetUrl } from '../lib/platform.js';
+import { resolveAssetUrl, restoreCachedAssetUrl } from '../lib/platform.js';
 import { stripInlineDiaryImages } from '../lib/diary-payload.js';
 
 function todayStr() {
@@ -50,20 +50,10 @@ function _stripCachedPaths(items) {
         return { ...i, imgUrl: i.imgUrl.slice(idx) };
       }
     } catch {}
-    // Capacitor cached path → only restore to /uploads/<filename> when the basename
-    // matches the server's localized image-naming pattern (timestamp-md5.ext, see
-    // server/lib/image-localizer.js). Externally-proxied images get cached under
-    // their source URL basename (e.g., 'front.en.6.400.jpg' from OFF), which does
-    // NOT correspond to any /uploads/ file — prepending /uploads/ would cross-
-    // pollinate images across diary items that share an OFF basename.
+    // Capacitor cache filenames are hashes and cannot be converted back by
+    // inspecting their basename. Recover the exact source from the cache map.
     if (i.imgUrl.includes('_capacitor_file_') || i.imgUrl.includes('/image_cache/')) {
-      const filename = i.imgUrl.split('/').pop();
-      if (filename && /^\d{10,}-[0-9a-f]{8,16}\.\w+$/i.test(filename)) {
-        return { ...i, imgUrl: '/uploads/' + filename };
-      }
-      // Cached basename doesn't match server's localized format — drop rather
-      // than guess. The diary item loses its image, but won't display the wrong one.
-      return { ...i, imgUrl: '' };
+      return { ...i, imgUrl: restoreCachedAssetUrl(i.imgUrl) || '' };
     }
     // Strip proxy URLs back to original (they get resolved at display time)
     if (i.imgUrl.includes('/api/proxy?url=')) {

--- a/src/stores/diary.js
+++ b/src/stores/diary.js
@@ -3,6 +3,7 @@ import { NtApi } from '../lib/api.js';
 import { Nutrition } from '../lib/nutrition.js';
 import { localDateStr, DB } from '../lib/db.js';
 import { resolveAssetUrl } from '../lib/platform.js';
+import { stripInlineDiaryImages } from '../lib/diary-payload.js';
 
 function todayStr() {
   return localDateStr();
@@ -36,7 +37,7 @@ function _fromApi(entry) {
 // Strip Capacitor file paths from imgUrl before sending to server
 function _stripCachedPaths(items) {
   if (!items || !Array.isArray(items)) return items;
-  return items.map(i => {
+  return stripInlineDiaryImages(items).map(i => {
     if (!i.imgUrl) return i;
     // Full server-host URL → strip back to relative /uploads/... path. See
     // _stripResolvedImgUrl in src/lib/api-cached.js for the same logic; both


### PR DESCRIPTION
I believe it will also fix #125

To reproduce issue we need to:
1.  Sync (open the app)
2. Add new food with a foto larger than 5MiB (most modern phones do this)

Server shows error, because it includes image of every diary item. Everything works even without this fix (as far as I can tell) because there is later will be sync event that syncs images and new foods.

I split this commit into two parts so you will be able to cherry-pick:

1. Fix itself strips image data from diary request, this allows it to stay well below 5MiB limit. And later sync will bring image.
2. Added `trace` log level with ability to show contents of request (stripped). 

Also good idea, if trace commit will be accepted, to update other apps and docs (since they share common env variables between each other)

I tested this change all at once with 3 combinations:
1. Old app - new server
2. New app - old server
3. Both new