### PR TITLE
fix: correct Open Food Facts country filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Open Food Facts country filtering now works for country-specific searches.** OFF search now uses the v2 search API with `countries_tags=en:<country>` filtering, and Norway is available in the OFF country dropdown.
+
 ---
 
 ## [1.0.5] - 2026-07-29

--- a/scripts/off-country-filter.test.js
+++ b/scripts/off-country-filter.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const apiJs = readFileSync(new URL('../src/lib/api.js', import.meta.url), 'utf8');
+const settingsSvelte = readFileSync(new URL('../src/routes/Settings.svelte', import.meta.url), 'utf8');
+const proxyJs = readFileSync(new URL('../server/routes/proxy.js', import.meta.url), 'utf8');
+
+test('Open Food Facts country search uses v2 countries_tags filtering', () => {
+  assert.match(apiJs, /world\.openfoodfacts\.org\/api\/v2\/search/);
+  assert.match(apiJs, /params\.set\('countries_tags', country\)/);
+  assert.match(apiJs, /`en:\$\{slug\}`/);
+  assert.doesNotMatch(apiJs, /countries_tags_en/);
+  assert.doesNotMatch(apiJs, /search\.openfoodfacts\.org\/search\?q=/);
+});
+
+test('Open Food Facts country options include Norway', () => {
+  assert.match(settingsSvelte, /OFF_COUNTRY_OPTS[\s\S]*'Norway'/);
+});
+
+test('local OFF proxy handles v2 search endpoint', () => {
+  assert.match(proxyJs, /world\.openfoodfacts\.org[\s\S]*\/api\/v2\/search/);
+  assert.match(proxyJs, /searchParams\.get\('search_terms'\)/);
+});

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -121,9 +121,10 @@ async function _tryLocalOff(parsedUrl) {
     logger.debug(`[off-local] barcode ${code} → hit from local mirror${airGap && result.status === 0 ? ' (air-gap, returning empty)' : ''}`);
     return result;
   }
-  // Name search: /search?q=...&page=...&page_size=...
-  if (host === 'search.openfoodfacts.org' && path === '/search') {
-    const q = parsedUrl.searchParams.get('q') || '';
+  // Name search: legacy /search?q=... and v2 /api/v2/search?search_terms=...
+  if ((host === 'search.openfoodfacts.org' && path === '/search') ||
+      (host === 'world.openfoodfacts.org' && path === '/api/v2/search')) {
+    const q = parsedUrl.searchParams.get('q') || parsedUrl.searchParams.get('search_terms') || '';
     const page = parseInt(parsedUrl.searchParams.get('page') || '1', 10);
     const pageSize = parseInt(parsedUrl.searchParams.get('page_size') || '20', 10);
     const result = await searchByName(q, { page, pageSize });

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -53,7 +53,7 @@ async function _extFetch(url) {
 }
 
 // Read the user's saved OFF country-filter preference from localStorage.
-// Returns the OFF tag form (lowercase, dashes for spaces) or null when
+// Returns the OFF countries_tags value (for example `en:norway`) or null when
 // the user picked 'World' or hasn't set anything. Reading direct from
 // localStorage instead of the store to keep this module store-free.
 function _getOffSearchCountry() {
@@ -64,8 +64,22 @@ function _getOffSearchCountry() {
     if (!raw) return null;
     const country = JSON.parse(raw);
     if (!country || country === 'World') return null;
-    return country.toLowerCase().replace(/\s+/g, '-');
+    const slug = country.toLowerCase().replace(/\s+/g, '-');
+    return slug.startsWith('en:') ? slug : `en:${slug}`;
   } catch { return null; }
+}
+
+function _offSearchUrl(query, page, pageSize) {
+  const params = new URLSearchParams({
+    search_terms: query,
+    json: '1',
+    page_size: String(pageSize),
+    page: String(page),
+    lc: _getOffSearchLanguage(),
+  });
+  const country = _getOffSearchCountry();
+  if (country) params.set('countries_tags', country);
+  return `https://world.openfoodfacts.org/api/v2/search?${params.toString()}`;
 }
 
 // Read the user's saved OFF language preference (short ISO 639-1 code
@@ -135,10 +149,7 @@ const API = {
   async searchByName(query, page) {
     page = page || 1;
     try {
-      const country = _getOffSearchCountry();
-      const cq = country ? `&countries_tags_en=${encodeURIComponent(country)}` : '';
-      const lc = `&lc=${encodeURIComponent(_getOffSearchLanguage())}`;
-      const offUrl = `https://search.openfoodfacts.org/search?q=${encodeURIComponent(query)}&json=1&page_size=50&page=${page}${cq}${lc}`;
+      const offUrl = _offSearchUrl(query, page, 50);
       const res = await _extFetch(offUrl);
       if (!res.ok) return [];
       const data = await res.json();
@@ -158,10 +169,7 @@ const API = {
   async searchByNameWithMeta(query, page, pageSize = 50) {
     page = page || 1;
     try {
-      const country = _getOffSearchCountry();
-      const cq = country ? `&countries_tags_en=${encodeURIComponent(country)}` : '';
-      const lc = `&lc=${encodeURIComponent(_getOffSearchLanguage())}`;
-      const offUrl = `https://search.openfoodfacts.org/search?q=${encodeURIComponent(query)}&json=1&page_size=${pageSize}&page=${page}${cq}${lc}`;
+      const offUrl = _offSearchUrl(query, page, pageSize);
       const res = await _extFetch(offUrl);
       if (!res.ok) return { items: [], totalHits: 0, page, hasMore: false };
       const data = await res.json();

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -538,7 +538,7 @@
     ['zh','Chinese'],['ar','Arabic'],['ko','Korean']
   ];
   const OFF_COUNTRY_OPTS = ['World','United States','United Kingdom','Australia','Canada',
-    'France','Germany','Spain','Italy','Mexico','Brazil','Japan','China','India'];
+    'France','Germany','Spain','Italy','Mexico','Brazil','Japan','China','India','Norway'];
   let offSearchLanguage = DB.getSetting('offSearchLanguage', 'en');
   let offSearchCountry  = DB.getSetting('offSearchCountry',  'World');
   let offUploadCountry  = DB.getSetting('offUploadCountry',  'Auto');


### PR DESCRIPTION
## Summary

Fixes Open Food Facts country-specific search and adds Norway to the OFF country dropdown.

This changes OFF name search to use the v2 search API with the standard `countries_tags=en:<country>` filter instead of the legacy `countries_tags_en=<country>` query shape.

Fixes #130.

## Changes

- Add Norway to the Open Food Facts country dropdown.
- Convert saved country selections to OFF country tags, for example:
  - `Norway` → `en:norway`
  - `France` → `en:france`
  - `Germany` → `en:germany`
  - `United States` → `en:united-states`
  - `United Kingdom` → `en:united-kingdom`
- Use the OFF API v2 search endpoint for name search:

```text
https://world.openfoodfacts.org/api/v2/search
```

- Apply country filtering via:

```text
countries_tags=en:<country-slug>
```

- Keep `World` as no country filter.
- Update the local OFF proxy path matching so local mirror mode still handles name-search requests through the v2 endpoint.
- Add a regression test covering:
  - API v2 search usage
  - `countries_tags` filtering
  - Norway in the country options
  - v2 search support in the local OFF proxy
- Add a changelog entry under `[Unreleased]`.

## Why v2?

The previous search URL used the legacy search endpoint with `countries_tags_en=<country>`.

For Norway, that URL shape reported matching counts but returned no product rows for Norwegian search terms.

Examples:

```text
https://search.openfoodfacts.org/search?q=melk&json=1&page_size=5&page=1&lc=en&countries_tags_en=norway
```

Observed:

```text
count: 164
products returned: 0
```

```text
https://search.openfoodfacts.org/search?q=smør&json=1&page_size=5&page=1&lc=en&countries_tags_en=norway
```

Observed:

```text
count: 18
products returned: 0
```

Open Food Facts does contain Norway-tagged products for these terms, for example:

```text
7025110090348 | Lettmelk 0,7% fett | countries_tags: ['en:norway']
7038010010347 | Meierismør | countries_tags: ['en:norway']
7025165008626 | Rugbrød med solsikkekjerner | countries_tags: ['en:norway']
```

Using API v2 with `countries_tags=en:norway` returns Norway-filtered products.

Example:

```text
https://world.openfoodfacts.org/api/v2/search?search_terms=ketchup&json=1&page_size=5&page=1&lc=en&countries_tags=en%3Anorway
```

Observed:

```text
count: 26365
products returned: 5
```

## Compatibility

This should not break existing countries because the same dropdown values are converted to the standard OFF country tag format:

- `France` → `en:france`
- `Germany` → `en:germany`
- `United States` → `en:united-states`
- `United Kingdom` → `en:united-kingdom`

`World` continues to send no country filter.

## Testing

Ran locally:

```text
npm test
npm run build
```

Both passed.

`npm run build` still reports existing Svelte/Vite accessibility and chunking warnings unrelated to this change.
