### PR TITLE
fix(android): preserve recipe-only diary items

### DIFF
--- a/scripts/android-recipe-diary.test.js
+++ b/scripts/android-recipe-diary.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { hydrateWithoutFoods } from '../src/lib/diary-hydration.js';
+
+const diaryStoreSrc = readFileSync(new URL('../src/stores/diary.js', import.meta.url), 'utf8');
+
+test('recipe-only hydration resolves diary items instead of returning Promises', async () => {
+  const recipe = {
+    id: 41,
+    is_recipe: 1,
+    name: 'Vegetable curry',
+    portion: 350,
+    unit: 'g',
+    nutrition: { calories: 420 },
+  };
+
+  const hydrated = await hydrateWithoutFoods([recipe], async item => item);
+
+  assert.deepEqual(hydrated, [recipe]);
+  assert.equal(hydrated[0] instanceof Promise, false);
+});
+
+test('recipe diary entries update meal usage rather than food usage', () => {
+  assert.match(
+    diaryStoreSrc,
+    /item\.is_recipe\s*\?\s*NtApi\.markMealUsed\(item\.id,\s*targetDate\)\s*:\s*NtApi\.markFoodUsed\(item\.id,\s*targetDate\)/,
+  );
+});

--- a/src/lib/db-native.js
+++ b/src/lib/db-native.js
@@ -8,6 +8,7 @@
  */
 
 import { CapacitorSQLite, SQLiteConnection } from '@capacitor-community/sqlite';
+import { hydrateWithoutFoods } from './diary-hydration.js';
 
 const LOCAL_USER_ID = 1;
 const DB_NAME = 'nutritrace_local';
@@ -799,7 +800,7 @@ async function _hydrateItems(items) {
         if (typeof id === 'number') foodIds.add(id);
       }
     }
-    if (!foodIds.size) return items.map(_hydrateSplitChildren);
+    if (!foodIds.size) return hydrateWithoutFoods(items, _hydrateSplitChildren);
     const db = await getDb();
     const placeholders = Array.from(foodIds).map(() => '?').join(',');
     const r = await db.query(

--- a/src/lib/diary-hydration.js
+++ b/src/lib/diary-hydration.js
@@ -1,0 +1,11 @@
+/**
+ * Resolve recipe split children when no food rows need database hydration.
+ *
+ * The child hydrator is async because split children can recursively require
+ * food lookups. Always await every result before the diary image pass reads
+ * item fields; returning the raw `map()` result would expose Promises instead
+ * of diary items for recipe-only days.
+ */
+export function hydrateWithoutFoods(items, hydrateSplitChildren) {
+  return Promise.all(items.map(hydrateSplitChildren));
+}

--- a/src/stores/diary.js
+++ b/src/stores/diary.js
@@ -288,11 +288,15 @@ export async function addDiaryItem(foodItem, meal, date) {
     items: [...(entry.items || []), item],
   }));
 
-  // Bump usage_count + last_used_at on the source food so it can rise in
-  // the "Most Used" / "Recently Used" sort modes. Fire-and-forget; a failed
-  // bump shouldn't block the diary save the user already saw succeed.
+  // Bump usage_count + last_used_at on the correct source table so foods,
+  // meals, and recipes can rise in their "Most Used" / "Recently Used"
+  // sort modes. Fire-and-forget; a failed bump shouldn't block the diary
+  // save the user already saw succeed.
   if (typeof item.id === 'number') {
-    NtApi.markFoodUsed(item.id, targetDate).catch(() => {});
+    const usageUpdate = item.is_recipe
+      ? NtApi.markMealUsed(item.id, targetDate)
+      : NtApi.markFoodUsed(item.id, targetDate);
+    usageUpdate.catch(() => {});
   }
 }
 


### PR DESCRIPTION
When you add recipe, through Android app, as a first item of the day it is added as 100g no-picture and no-nutrients entry.

There is one single place that lead to this:
https://github.com/TraceApps/nutritrace/blob/dev/src/lib/db-native.js#L797 and here recipes are excluded and not becoming part of foodIds, and then it takes this path https://github.com/TraceApps/nutritrace/blob/dev/src/lib/db-native.js#L802 where_hydrateSplitChildren returns Promise
And here it becomes undefined https://github.com/TraceApps/nutritrace/blob/dev/src/lib/db-native.js#L869-L871 hence 100g without nutrients and image.

src/stores/diary.js fixes additional case where adding recipe bumps recent usage for some random food item with the same id.