### PR TITLE
fix(images): share square cropper across editors

### DIFF
--- a/scripts/crop-geometry.test.js
+++ b/scripts/crop-geometry.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { centeredSquareCrop, moveSquareCrop, resizeSquareCrop } from '../src/lib/crop-geometry.js';
+
+test('crop starts centered and square inside the rendered image', () => {
+  assert.deepEqual(centeredSquareCrop(400, 300), { x: 80, y: 30, size: 240 });
+  assert.deepEqual(centeredSquareCrop(200, 500), { x: 20, y: 170, size: 160 });
+});
+
+test('moving a crop remains inside image bounds', () => {
+  const crop = { x: 20, y: 30, size: 160 };
+  assert.deepEqual(moveSquareCrop(crop, -100, 500, 300, 250), { x: 0, y: 90, size: 160 });
+});
+
+test('resizing remains square and respects minimum and image bounds', () => {
+  const crop = { x: 40, y: 30, size: 160 };
+  assert.deepEqual(resizeSquareCrop(crop, 200, 100, 300, 260), { x: 40, y: 30, size: 230 });
+  assert.deepEqual(resizeSquareCrop(crop, -500, -300, 300, 260), { x: 40, y: 30, size: 48 });
+});
+
+test('food and recipe editors both use the shared pointer-event cropper', () => {
+  for (const path of ['src/routes/FoodEditor.svelte', 'src/routes/MealEditor.svelte']) {
+    assert.match(readFileSync(path, 'utf8'), /<ImageCropper/);
+  }
+  const component = readFileSync('src/components/ui/ImageCropper.svelte', 'utf8');
+  assert.match(component, /on:pointerdown/);
+  assert.match(component, /on:pointermove/);
+  assert.match(component, /crop-resize-handle/);
+});

--- a/src/components/ui/ImageCropper.svelte
+++ b/src/components/ui/ImageCropper.svelte
@@ -1,0 +1,205 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import { portal } from '../../lib/portal.js';
+  import { centeredSquareCrop, moveSquareCrop, resizeSquareCrop } from '../../lib/crop-geometry.js';
+
+  export let src = '';
+  export let title = 'Crop Photo';
+  export let hint = 'Drag to reposition; drag the corner to resize';
+  export let confirmLabel = 'Crop & Use';
+  export let cancelLabel = 'Cancel';
+  export let outputSize = null;
+
+  const dispatch = createEventDispatcher();
+  let container;
+  let image;
+  let imageOffsetX = 0;
+  let crop = { x: 0, y: 0, size: 0 };
+  let interaction = null;
+
+  function initializeCrop() {
+    if (!image) return;
+    imageOffsetX = image.offsetLeft;
+    crop = centeredSquareCrop(image.offsetWidth, image.offsetHeight);
+  }
+
+  function startInteraction(event, mode) {
+    if (event.button != null && event.button !== 0) return;
+    interaction = {
+      mode,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      crop: { ...crop },
+    };
+    container?.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  }
+
+  function updateInteraction(event) {
+    if (!interaction || event.pointerId !== interaction.pointerId || !image) return;
+    const deltaX = event.clientX - interaction.startX;
+    const deltaY = event.clientY - interaction.startY;
+    crop = interaction.mode === 'move'
+      ? moveSquareCrop(interaction.crop, deltaX, deltaY, image.offsetWidth, image.offsetHeight)
+      : resizeSquareCrop(interaction.crop, deltaX, deltaY, image.offsetWidth, image.offsetHeight);
+    event.preventDefault();
+  }
+
+  function endInteraction(event) {
+    if (!interaction || event.pointerId !== interaction.pointerId) return;
+    if (container?.hasPointerCapture?.(event.pointerId)) container.releasePointerCapture(event.pointerId);
+    interaction = null;
+  }
+
+  function confirm() {
+    if (!image || crop.size <= 0) return;
+    const scaleX = image.naturalWidth / image.offsetWidth;
+    const scaleY = image.naturalHeight / image.offsetHeight;
+    const naturalCropSize = Math.max(1, Math.round(Math.min(crop.size * scaleX, crop.size * scaleY)));
+    const finalSize = outputSize == null ? naturalCropSize : Math.max(1, Math.round(outputSize));
+    const canvas = document.createElement('canvas');
+    canvas.width = finalSize;
+    canvas.height = finalSize;
+    canvas.getContext('2d').drawImage(
+      image,
+      crop.x * scaleX,
+      crop.y * scaleY,
+      crop.size * scaleX,
+      crop.size * scaleY,
+      0,
+      0,
+      finalSize,
+      finalSize,
+    );
+    dispatch('confirm', { dataUrl: canvas.toDataURL('image/jpeg', 0.9) });
+  }
+</script>
+
+<div class="crop-overlay" role="dialog" aria-modal="true" use:portal>
+  <div class="crop-popup">
+    <div class="crop-header">
+      <span class="crop-title">{title}</span>
+      <button class="btn-icon" on:click={() => dispatch('cancel')} aria-label={cancelLabel} title={cancelLabel}>
+        <span class="material-symbols-rounded">close</span>
+      </button>
+    </div>
+    <p class="crop-hint">{hint}</p>
+    <div
+      class="crop-container"
+      bind:this={container}
+      on:pointermove={updateInteraction}
+      on:pointerup={endInteraction}
+      on:pointercancel={endInteraction}
+      role="img"
+      aria-label={title}
+    >
+      <img bind:this={image} {src} class="crop-image" alt="" draggable="false" on:load={initializeCrop} />
+      {#if crop.size > 0}
+        <div
+          class="crop-box"
+          class:dragging={interaction?.mode === 'move'}
+          style="left:{imageOffsetX + crop.x}px;top:{crop.y}px;width:{crop.size}px;height:{crop.size}px"
+          on:pointerdown={(event) => startInteraction(event, 'move')}
+          role="button"
+          tabindex="0"
+          aria-label="Drag to reposition crop"
+          on:keydown={() => {}}
+        >
+          <button
+            type="button"
+            class="crop-resize-handle"
+            on:pointerdown|stopPropagation={(event) => startInteraction(event, 'resize')}
+            aria-label="Drag to resize crop"
+          ></button>
+        </div>
+      {/if}
+    </div>
+    <div class="crop-footer">
+      <button class="btn btn-primary" on:click={confirm}>{confirmLabel}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .crop-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .crop-popup {
+    width: min(480px, 96vw);
+    overflow: hidden;
+    border-radius: var(--radius-xl);
+    background: var(--surface-1);
+    display: flex;
+    flex-direction: column;
+  }
+  .crop-header {
+    padding: 16px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+  }
+  .crop-title { font-size: 17px; font-weight: 600; }
+  .crop-hint { margin: 0; padding: 8px 16px; font-size: 12px; color: var(--text-3); }
+  .crop-container {
+    position: relative;
+    overflow: hidden;
+    user-select: none;
+    touch-action: none;
+  }
+  .crop-image {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    max-height: 55vh;
+    user-select: none;
+    pointer-events: none;
+  }
+  .crop-box {
+    position: absolute;
+    box-sizing: border-box;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+    cursor: grab;
+    touch-action: none;
+  }
+  .crop-box.dragging { cursor: grabbing; }
+  .crop-resize-handle {
+    position: absolute;
+    right: -2px;
+    bottom: -2px;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    border: 0;
+    border-radius: 14px 0 0 0;
+    background: var(--accent);
+    cursor: nwse-resize;
+    touch-action: none;
+  }
+  .crop-resize-handle::before {
+    content: '';
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    width: 10px;
+    height: 10px;
+    border-right: 2px solid #fff;
+    border-bottom: 2px solid #fff;
+  }
+  .crop-footer {
+    padding: 16px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1193,7 +1193,7 @@
     "card_nutrition":    "Nutrition",
     "take_photo":        "Take Photo",
     "crop_photo":        "Crop Photo",
-    "crop_hint":         "Drag the box to reposition",
+    "crop_hint":         "Drag the box to reposition; drag the corner to resize",
     "field_brand":       "Brand",
     "field_serving_size":"Serving Size",
     "field_unit":        "Unit",

--- a/src/lib/crop-geometry.js
+++ b/src/lib/crop-geometry.js
@@ -1,0 +1,33 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export function centeredSquareCrop(width, height, coverage = 0.8) {
+  const safeWidth = Math.max(0, Number(width) || 0);
+  const safeHeight = Math.max(0, Number(height) || 0);
+  const safeCoverage = clamp(Number(coverage) || 0.8, 0.1, 1);
+  const size = Math.round(Math.min(safeWidth, safeHeight) * safeCoverage);
+
+  return {
+    x: Math.round((safeWidth - size) / 2),
+    y: Math.round((safeHeight - size) / 2),
+    size,
+  };
+}
+
+export function moveSquareCrop(crop, deltaX, deltaY, width, height) {
+  return {
+    ...crop,
+    x: clamp(crop.x + deltaX, 0, Math.max(0, width - crop.size)),
+    y: clamp(crop.y + deltaY, 0, Math.max(0, height - crop.size)),
+  };
+}
+
+export function resizeSquareCrop(crop, deltaX, deltaY, width, height, minSize = 48) {
+  const dominantDelta = Math.abs(deltaX) >= Math.abs(deltaY) ? deltaX : deltaY;
+  const maxSize = Math.max(0, Math.min(width - crop.x, height - crop.y));
+  const effectiveMin = Math.min(Math.max(1, minSize), maxSize);
+
+  return {
+    ...crop,
+    size: clamp(crop.size + dominantDelta, effectiveMin, maxSize),
+  };
+}

--- a/src/routes/FoodEditor.svelte
+++ b/src/routes/FoodEditor.svelte
@@ -11,6 +11,7 @@
   import { editorState, clearFoodEditorState } from '../stores/editorState.js';
   import Toggle from '../components/settings/Toggle.svelte';
   import UnitPicker from '../components/ui/UnitPicker.svelte';
+  import ImageCropper from '../components/ui/ImageCropper.svelte';
   import { takePhoto } from '../lib/camera.js';
   import { isNative } from '../lib/platform.js';
   import BarcodeScanner from '../components/foods/BarcodeScanner.svelte';
@@ -33,9 +34,6 @@
   let cameraStream = null;
   let showCrop    = false;
   let cropSrc     = '';
-  let cropImg     = null;
-  let cropBox     = null;
-  let cropDragging = false, cropStartX, cropStartY, cropOrigL, cropOrigT;
 
   function openGallery() { fileInput && fileInput.click(); }
 
@@ -106,49 +104,6 @@
   }
 
   function removePhoto() { food.imgUrl = ''; }
-
-  // Crop UI helpers
-  function onCropImgLoad() {
-    if (!cropImg || !cropBox) return;
-    const w = cropImg.offsetWidth, h = cropImg.offsetHeight;
-    cropBox.style.left   = Math.round(w * 0.1) + 'px';
-    cropBox.style.top    = Math.round(h * 0.1) + 'px';
-    cropBox.style.width  = Math.round(w * 0.8) + 'px';
-    cropBox.style.height = Math.round(h * 0.8) + 'px';
-  }
-
-  function cropStartDrag(e) {
-    cropDragging = true;
-    const pt = e.touches ? e.touches[0] : e;
-    cropStartX = pt.clientX; cropStartY = pt.clientY;
-    cropOrigL = parseInt(cropBox.style.left); cropOrigT = parseInt(cropBox.style.top);
-    e.preventDefault();
-  }
-
-  function cropMoveDrag(e) {
-    if (!cropDragging || !cropImg || !cropBox) return;
-    const pt = e.touches ? e.touches[0] : e;
-    const w = cropImg.offsetWidth, h = cropImg.offsetHeight;
-    cropBox.style.left = Math.max(0, Math.min(w - parseInt(cropBox.style.width),  cropOrigL + pt.clientX - cropStartX)) + 'px';
-    cropBox.style.top  = Math.max(0, Math.min(h - parseInt(cropBox.style.height), cropOrigT + pt.clientY - cropStartY)) + 'px';
-  }
-
-  function cropEndDrag() { cropDragging = false; }
-
-  function confirmCrop() {
-    if (!cropImg || !cropBox) return;
-    const scaleX = cropImg.naturalWidth  / cropImg.offsetWidth;
-    const scaleY = cropImg.naturalHeight / cropImg.offsetHeight;
-    const cx = parseInt(cropBox.style.left) * scaleX;
-    const cy = parseInt(cropBox.style.top)  * scaleY;
-    const cw = parseInt(cropBox.style.width)  * scaleX;
-    const ch = parseInt(cropBox.style.height) * scaleY;
-    const canvas = document.createElement('canvas');
-    canvas.width = cw; canvas.height = ch;
-    canvas.getContext('2d').drawImage(cropImg, cx, cy, cw, ch, 0, 0, cw, ch);
-    food.imgUrl = canvas.toDataURL('image/jpeg', 0.9);
-    showCrop = false; cropSrc = '';
-  }
 
   export let params = {};
 
@@ -832,32 +787,18 @@
 
     <!-- Crop popup -->
     {#if showCrop}
-      <div class="cam-overlay" role="dialog" aria-modal="true" use:portal>
-        <div class="cam-popup">
-          <div class="cam-header">
-            <span class="cam-title">{$_('food_editor.crop_photo')}</span>
-            <button class="btn-icon" on:click={() => { showCrop = false; cropSrc = ''; }} aria-label={$_('food_editor.cancel')} title={$_('food_editor.cancel')}>
-              <span class="material-symbols-rounded">close</span>
-            </button>
-          </div>
-          <p class="crop-hint">{$_('food_editor.crop_hint')}</p>
-          <div class="crop-container"
-            on:mousemove={cropMoveDrag}
-            on:touchmove={cropMoveDrag}
-            on:mouseup={cropEndDrag}
-            on:touchend={cropEndDrag}
-          >
-            <img bind:this={cropImg} src={cropSrc} class="crop-img" alt="Crop" on:load={onCropImgLoad} />
-            <div bind:this={cropBox} class="crop-box"
-              on:mousedown={cropStartDrag}
-              on:touchstart={cropStartDrag}
-            ></div>
-          </div>
-          <div class="cam-footer">
-            <button class="btn btn-primary" on:click={confirmCrop}>Crop &amp; Use</button>
-          </div>
-        </div>
-      </div>
+      <ImageCropper
+        src={cropSrc}
+        title={$_('food_editor.crop_photo')}
+        hint={$_('food_editor.crop_hint')}
+        cancelLabel={$_('food_editor.cancel')}
+        on:confirm={(event) => {
+          food.imgUrl = event.detail.dataUrl;
+          showCrop = false;
+          cropSrc = '';
+        }}
+        on:cancel={() => { showCrop = false; cropSrc = ''; }}
+      />
     {/if}
 
     <!-- Basic info -->
@@ -1438,18 +1379,6 @@
     flex-shrink: 0;
   }
   :global(.cam-capture-btn) { gap: 6px; min-width: 140px; }
-  :global(.crop-hint) { padding: 8px 16px 0; font-size: 12px; color: var(--text-3); }
-  :global(.crop-container) { position: relative; overflow: hidden; user-select: none; touch-action: none; }
-  :global(.crop-img) { display: block; max-width: 100%; max-height: 55vh; user-select: none; }
-  :global(.crop-box) {
-    position: absolute;
-    border: 2px solid #fff;
-    box-shadow: 0 0 0 9999px rgba(0,0,0,0.5);
-    cursor: move;
-    box-sizing: border-box;
-    touch-action: none;
-  }
-
   /* Scan Label button — sits in the Nutrition card title row. Icon + text
      so the action is obvious (camera alone could be confused with food
      photo / profile picture). Compact enough to fit the title row on

--- a/src/routes/MealEditor.svelte
+++ b/src/routes/MealEditor.svelte
@@ -12,6 +12,7 @@
   import Sheet from '../components/ui/Sheet.svelte';
   import Spinner from '../components/ui/Spinner.svelte';
   import UnitPicker from '../components/ui/UnitPicker.svelte';
+  import ImageCropper from '../components/ui/ImageCropper.svelte';
   import { scaleFactor as _unitScaleFactor, amountAndUnit } from '../lib/units.js';
   import { showSuccess, showError } from '../stores/toast.js';
   import { editorState, clearMealEditorState } from '../stores/editorState.js';
@@ -41,9 +42,6 @@
   let videoEl = null;
   let cropOpen = false;
   let cropSrc = '';
-  let cropImgEl = null;
-  let cropBoxX = 0, cropBoxY = 0, cropBoxSize = 200;
-  let cropDragging = false, cropDragStartX = 0, cropDragStartY = 0, cropBoxStartX = 0, cropBoxStartY = 0;
 
   // Recipe fields. recipeAmount is the TOTAL weight of the finished dish
   // (auto-filled from ingredients; user can override for boil-off). recipeYields
@@ -153,7 +151,7 @@
     if (!file) return;
     const reader = new FileReader();
     reader.onload = async ev => {
-      if ($cropPhotos) { cropSrc = ev.target.result; cropOpen = true; initCropBox(); }
+      if ($cropPhotos) { cropSrc = ev.target.result; cropOpen = true; }
       else { photoPreviewUrl = await fitImageDataUrl(ev.target.result); }
     };
     reader.readAsDataURL(file);
@@ -167,7 +165,7 @@
         if (!file) return;
         const reader = new FileReader();
         reader.onload = async ev => {
-          if ($cropPhotos) { cropSrc = ev.target.result; cropOpen = true; initCropBox(); }
+          if ($cropPhotos) { cropSrc = ev.target.result; cropOpen = true; }
           else { photoPreviewUrl = await fitImageDataUrl(ev.target.result); }
         };
         reader.readAsDataURL(file);
@@ -189,7 +187,7 @@
     canvas.getContext('2d').drawImage(videoEl, 0, 0);
     const dataUrl = canvas.toDataURL('image/jpeg', 0.9);
     closeCamera();
-    if ($cropPhotos) { cropSrc = dataUrl; cropOpen = true; initCropBox(); }
+    if ($cropPhotos) { cropSrc = dataUrl; cropOpen = true; }
     else { photoPreviewUrl = await fitImageDataUrl(dataUrl); }
   }
 
@@ -197,41 +195,6 @@
     if (cameraStream) { cameraStream.getTracks().forEach(t => t.stop()); cameraStream = null; }
     cameraOpen = false;
   }
-
-  function initCropBox() {
-    cropBoxX = 20; cropBoxY = 20; cropBoxSize = 200;
-  }
-
-  function confirmCrop() {
-    if (!cropImgEl) return;
-    const canvas = document.createElement('canvas');
-    const scaleX = cropImgEl.naturalWidth / cropImgEl.offsetWidth;
-    const scaleY = cropImgEl.naturalHeight / cropImgEl.offsetHeight;
-    canvas.width = 300; canvas.height = 300;
-    canvas.getContext('2d').drawImage(
-      cropImgEl,
-      cropBoxX * scaleX, cropBoxY * scaleY,
-      cropBoxSize * scaleX, cropBoxSize * scaleY,
-      0, 0, 300, 300
-    );
-    photoPreviewUrl = canvas.toDataURL('image/jpeg', 0.85);
-    cropOpen = false; cropSrc = '';
-  }
-
-  function onCropMouseDown(e) {
-    cropDragging = true;
-    cropDragStartX = e.clientX; cropDragStartY = e.clientY;
-    cropBoxStartX = cropBoxX; cropBoxStartY = cropBoxY;
-    e.preventDefault();
-  }
-  function onCropMouseMove(e) {
-    if (!cropDragging || !cropImgEl) return;
-    const maxX = cropImgEl.offsetWidth - cropBoxSize;
-    const maxY = cropImgEl.offsetHeight - cropBoxSize;
-    cropBoxX = Math.max(0, Math.min(maxX, cropBoxStartX + (e.clientX - cropDragStartX)));
-    cropBoxY = Math.max(0, Math.min(maxY, cropBoxStartY + (e.clientY - cropDragStartY)));
-  }
-  function onCropMouseUp() { cropDragging = false; }
 
   // ── Ingredient picker ──────────────────────────────────────────────────────
   async function openPicker() {
@@ -1137,32 +1100,20 @@
 
 <!-- ── Crop overlay ── -->
 {#if cropOpen}
-  <div class="cam-overlay" role="dialog" aria-modal="true" use:portal>
-    <div class="cam-popup">
-      <div class="cam-header">
-        <span class="cam-title">{$_('meal_editor_deep.crop_photo')}</span>
-        <button class="btn-icon" on:click={() => { cropOpen = false; cropSrc = ''; }} title="Cancel">
-          <span class="material-symbols-rounded">close</span>
-        </button>
-      </div>
-      <div class="crop-container"
-        on:mousemove={onCropMouseMove}
-        on:mouseup={onCropMouseUp}
-        on:mouseleave={onCropMouseUp}
-        role="img" aria-label="Crop area">
-        <img bind:this={cropImgEl} src={cropSrc} alt="crop" class="crop-img" draggable="false" />
-        <div class="crop-box"
-          style="left:{cropBoxX}px;top:{cropBoxY}px;width:{cropBoxSize}px;height:{cropBoxSize}px"
-          on:mousedown={onCropMouseDown}
-          role="button" tabindex="0"
-          aria-label="Drag to reposition crop"
-          on:keydown={() => {}}></div>
-      </div>
-      <div class="cam-footer">
-        <button class="btn btn-primary cam-capture-btn" on:click={confirmCrop}>{$_('meal_editor.use_this_crop')}</button>
-      </div>
-    </div>
-  </div>
+  <ImageCropper
+    src={cropSrc}
+    title={$_('meal_editor_deep.crop_photo')}
+    hint={$_('food_editor.crop_hint')}
+    confirmLabel={$_('meal_editor.use_this_crop')}
+    cancelLabel={$_('food_editor.cancel')}
+    outputSize={300}
+    on:confirm={(event) => {
+      photoPreviewUrl = event.detail.dataUrl;
+      cropOpen = false;
+      cropSrc = '';
+    }}
+    on:cancel={() => { cropOpen = false; cropSrc = ''; }}
+  />
 {/if}
 
 <style>
@@ -1399,11 +1350,4 @@
   .picker-info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
   .picker-name { font-size: 14px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
-  /* Camera / Crop overlays — shared styles live in FoodEditor's :global CSS */
-  :global(.crop-box) {
-    position: absolute;
-    border: 2px solid var(--accent);
-    cursor: grab;
-    box-shadow: 0 0 0 9999px rgba(0,0,0,0.45);
-  }
 </style>


### PR DESCRIPTION
Current image cropper has two big problems:
1. Recipe/Food/Meal (idk about Meal, never used it tbh) image cropper are different
2. Recipe has weird fixed in upper-ish-left-ish corner crop box that you can move anywhere nor resize.

This one is the same across all food-types and also has ability to resize (square only) crop area

Enjoy photo of one of my cats (Sam):

<img width="892" height="1280" alt="image" src="https://github.com/user-attachments/assets/6a6ef3ec-7e1e-44f6-8077-3779eafb3485" />
