### PR TITLE
fix(dev): make Vite usable over LAN and stop blank boots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Vite LAN / blank-boot hang.** Dev server now binds all interfaces, allows any Host header, and sends CORS so a second PC on the LAN can load the unbundled module graph. IndexedDB open is timed out after 8s instead of leaving a blank `#app`, and a visible boot status is shown until the Svelte app mounts.
 - **Clearing the Trace chat now asks for confirmation.** A single tap on the header button previously wiped the entire conversation with no way back. Ports the same guard LiftTrace added in [TraceApps/lifttrace#50](https://github.com/TraceApps/lifttrace/pull/50) so behavior stays uniform across the three Trace apps. Also fixes a z-index bug where the confirm dialog opened behind the Trace panel.
 
 ---

--- a/index.html
+++ b/index.html
@@ -58,7 +58,30 @@
        by src/components/foods/BarcodeScanner.svelte → _loadBarcodeLibs(). -->
 </head>
 <body>
+  <p id="nt-boot" style="margin:40vh auto;max-width:28rem;text-align:center;color:#8b90a0;font:15px/1.4 Inter,system-ui,sans-serif">
+    Loading NutriTrace…
+  </p>
   <div id="app"></div>
+  <script>
+    (function () {
+      function msg(t) {
+        if (window.__NT_BOOTED__) return;
+        var el = document.getElementById('nt-boot');
+        if (el) el.textContent = t;
+      }
+      fetch('/api/health', { cache: 'no-store' })
+        .then(function (r) { return r.json(); })
+        .then(function (j) { msg(j && j.ok ? 'API connected. Loading UI…' : 'API responded, not ok. Loading UI…'); })
+        .catch(function () { msg('API unreachable. Loading UI anyway…'); });
+      window.addEventListener('error', function (e) {
+        msg('Load error: ' + (e.message || e.filename || 'unknown'));
+      });
+      window.addEventListener('unhandledrejection', function (e) {
+        var r = e.reason;
+        msg('Load error: ' + ((r && r.message) || r || 'unhandled rejection'));
+      });
+    })();
+  </script>
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,13 @@ import './styles/forms.css';
 import App from './App.svelte';
 import { DB } from './lib/db.js';
 import { initI18n } from './i18n/index.js';
+import { isNative, loadImageMap } from './lib/platform.js';
+
+function _bootMsg(text) {
+  if (window.__NT_BOOTED__) return;
+  const el = document.getElementById('nt-boot');
+  if (el) el.textContent = text;
+}
 
 // Pick browser-detected locale for first paint; the App-level subscription to
 // the `language` store flips it to the user's saved preference once that loads.
@@ -34,17 +41,30 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e =
   }
 });
 
-// Boot
-DB.init()
+// Boot. Time out IndexedDB so a hung open (common in embedded browsers)
+// cannot leave #app blank forever.
+_bootMsg('Opening local database…');
+const _dbInit = Promise.race([
+  DB.init(),
+  new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('IndexedDB open timed out')), 8000)
+  ),
+]);
+
+_dbInit
   .then(async () => {
     // Load cached image map before app renders — ensures resolveAssetUrl() has the map
     // ready on first paint (local SQLite read, no server dependency, ~5ms)
-    const { isNative } = await import('./lib/platform.js');
     if (isNative) {
-      const { loadImageMap } = await import('./lib/platform.js');
       await loadImageMap();
     }
-    new App({ target: document.getElementById('app') });
+    _bootMsg('Loading app…');
+    window.__NT_BOOTED__ = true;
+    const bootEl = document.getElementById('nt-boot');
+    if (bootEl) bootEl.remove();
+    const root = document.getElementById('app');
+    root.innerHTML = '';
+    new App({ target: root });
   })
   .catch(err => {
     console.error('DB init failed:', err);

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,9 +9,17 @@ export default defineConfig({
   // without a rebuild.
   base: './',
   server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
+    allowedHosts: true,
+    cors: true,
+    warmup: {
+      clientFiles: ['./src/main.js', './src/App.svelte'],
+    },
     proxy: {
-      '/api':     'http://localhost:3001',
-      '/uploads': 'http://localhost:3001',
+      '/api':     { target: 'http://127.0.0.1:3001', changeOrigin: true },
+      '/uploads': { target: 'http://127.0.0.1:3001', changeOrigin: true },
     }
   },
   build: {


### PR DESCRIPTION
## Summary
- Bind the Vite dev server on all interfaces with CORS + `allowedHosts` so a second PC on the LAN can load the unbundled module graph (was failing with `Failed to fetch dynamically imported module`).
- Show a boot status instead of a blank `#app`, and time out a hung IndexedDB open after 8s.

## Test plan
- [ ] `npm run dev` still serves at http://localhost:5173 and proxies `/api` + `/uploads` to `:3001`
- [ ] From another device on the same LAN, open `http://<dev-host>:5173/` and confirm the UI mounts (login or diary)
- [ ] Confirm HMR still works on localhost after a Svelte edit
- [ ] If IndexedDB is blocked (embedded browser), confirm the Database Error screen appears instead of an infinite blank page


Made with [Cursor](https://cursor.com)