### PR TITLE
Fix stale percent mode when applying macro presets

### DIFF
--- a/scripts/goals-macro-preset.test.js
+++ b/scripts/goals-macro-preset.test.js
@@ -1,0 +1,38 @@
+/**
+ * Static regression coverage for macro presets in Goals.svelte.
+ *
+ * Goals currently has no component-test harness, so these checks ensure each
+ * gram-based preset resets percent mode after preserving prior goal settings.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const goalsSrc = readFileSync(new URL('../src/routes/Goals.svelte', import.meta.url), 'utf8');
+const presetBlock = goalsSrc.match(/function applyMacroPreset\(name\) \{[\s\S]*?showSuccess\('Macros set'\);\n  \}/)?.[0];
+
+test('macro presets calculate gram targets using the correct calorie densities', () => {
+  assert.ok(presetBlock, 'applyMacroPreset function not found');
+  assert.match(presetBlock, /const pG = Math\.round\(kcal \* preset\.p \/ 100 \/ 4\)/);
+  assert.match(presetBlock, /const cG = Math\.round\(kcal \* preset\.c \/ 100 \/ 4\)/);
+  assert.match(presetBlock, /const fG = Math\.round\(kcal \* preset\.f \/ 100 \/ 9\)/);
+});
+
+for (const [macro, target] of [
+  ['proteins', 'pG'],
+  ['carbohydrates', 'cG'],
+  ['fat', 'fG'],
+]) {
+  test(`macro presets reset percent mode for ${macro} after merging existing settings`, () => {
+    assert.ok(presetBlock, 'applyMacroPreset function not found');
+    const line = presetBlock.split('\n').find(value => value.trimStart().startsWith(`${macro}:`));
+    assert.ok(line, `${macro} preset goal not found`);
+
+    const spreadAt = line.indexOf(`...(g.${macro}`);
+    const resetAt = line.indexOf('isPercent: false');
+    const targetAt = line.indexOf(`max: ${target}`);
+    assert.ok(spreadAt >= 0, `${macro} should preserve existing goal settings`);
+    assert.ok(resetAt > spreadAt, `${macro} must reset isPercent after existing settings are merged`);
+    assert.ok(targetAt > resetAt, `${macro} should store the calculated gram target`);
+  });
+}

--- a/src/routes/Goals.svelte
+++ b/src/routes/Goals.svelte
@@ -629,9 +629,9 @@
     const fG = Math.round(kcal * preset.f / 100 / 9);
     goals.update(g => ({
       ...g,
-      proteins:      { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.proteins      || {}), max: pG, min: undefined, days: Array(7).fill(pG) },
-      carbohydrates: { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.carbohydrates || {}), max: cG, min: undefined, days: Array(7).fill(cG) },
-      fat:           { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.fat           || {}), max: fG, min: undefined, days: Array(7).fill(fG) },
+      proteins:      { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.proteins      || {}), isPercent: false, max: pG, min: undefined, days: Array(7).fill(pG) },
+      carbohydrates: { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.carbohydrates || {}), isPercent: false, max: cG, min: undefined, days: Array(7).fill(cG) },
+      fat:           { sharedGoal: true, isMin: false, showInDiary: true, showInStats: true, ...(g.fat           || {}), isPercent: false, max: fG, min: undefined, days: Array(7).fill(fG) },
     }));
     showSuccess('Macros set');
   }


### PR DESCRIPTION
## Summary

Macro presets calculate gram targets for Protein, Carbohydrates, and Fat, but previously preserved an existing goal's `isPercent` state.

If a macro had "As percent" enabled before applying a preset, the preset's newly calculated gram value could later be interpreted as a percentage by the Diary, producing a greatly inflated target.

This change explicitly resets `isPercent` to `false` for all three macros when a macro preset is applied.

## Reproduction

1. Open Goals.
2. Enable "As percent" for Protein, Carbohydrates, or Fat.
3. Save the goal.
4. Apply Balanced 30/40/30 or another macro preset.
5. Open Diary / Overview and switch the macro display to grams.
6. Observe that the preset-created target is inflated because the numeric gram target is still being interpreted as a percentage.

This was reproduced independently with Protein, Carbohydrates, and Fat.

Example:

With a 1,828 kcal goal, Balanced calculates Protein at approximately 137 g.

With stale `isPercent=true`, Diary interprets that as 137%:

1,828 × 1.37 ÷ 4 ≈ 626 g

## Fix

Preset-created Protein, Carbohydrates, and Fat goals now explicitly reset `isPercent` to `false` after existing goal state is merged.

## Testing

- `node --test scripts/goals-macro-preset.test.js` — passed, 4/4
- `npm test` — passed, 118/118
- `npm run i18n:check` — passed
- `npm run build` — passed with existing Vite/Svelte warnings

No lint or typecheck scripts are defined in the repository.

Fixes #209